### PR TITLE
Fix and add tests for MAP_CLAIM_TO_MODEL settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 # Python files
 *.egg-info/
 __pycache__/
+build/
 dist/
 .tox/


### PR DESCRIPTION
- validate none standard 'email' field is supported with MAP_CLAIM_MODEL
  settings.
- use email as username
- moves the config inside the class methods to support test overriding

Closes #14