### PR TITLE
Add support for ID Tokens with the `emails` claim

### DIFF
--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -204,7 +204,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                     user = self.user_model.objects.get(email=email)
                 elif not email and "emails" in user_data.keys():
                     emails = user_data.get("emails")
-                    user = self.user_model.objects.filter(email__in=user_data.get("emails")).first()
+                    user = self.user_model.objects.filter(
+                        email__in=user_data.get("emails")
+                    ).first()
                     if not user:
                         # If a user does not exist for all the users valid emails
                         # set the `email` claim to the first email in the `emails`


### PR DESCRIPTION
# Changes

- Added support for ID Tokens that come in with the `emails` claim; Checks if any user account has been created for any of the verified emails first if there are none the application sets the `email` used to create the User to the first email in the list of emails