### PR TITLE
Fix template syntax

### DIFF
--- a/oidc/__init__.py
+++ b/oidc/__init__.py
@@ -2,6 +2,6 @@
 Main init file for oidc app
 """
 
-VERSION = (0, 0, 8)
+VERSION = (0, 0, 9)
 __version__ = ".".join(str(v) for v in VERSION)
 default_app_config = "oidc.apps.oidcConfig"

--- a/oidc/templates/oidc/oidc_unrecoverable_error.html
+++ b/oidc/templates/oidc/oidc_unrecoverable_error.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load rest_framework %}
 
-{% block title %}Error: {{ error-title }}{% endblock %}
+{% block title %}Error: {{ error_title }}{% endblock %}
 
 {% block content %}
 <div class="content">

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -262,7 +262,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                                     "error": _(
                                         f"Missing required fields: {missing_fields}"
                                     ),
-                                    "error-title": _("Missing details in ID Token"),
+                                    "error_title": _("Missing details in ID Token"),
                                 },
                                 status=status.HTTP_400_BAD_REQUEST,
                                 template_name="oidc/oidc_unrecoverable_error.html",
@@ -289,7 +289,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                             "error": _(
                                 "Unable to validate authentication request; Nonce verification has failed. Kindly retry authentication process."
                             ),
-                            "error-title": _(
+                            "error_title": _(
                                 "Authentication request verification failed"
                             ),
                         },


### PR DESCRIPTION
# Changes

- Rename `error-title` to `error_title`
- Test that errors are returned when a claim is missing