### PR TITLE
Handle replacement of invalid characters when using the email username segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ OPENID_CONNECT_VIEWSET_CONFIG = {
     "AUTH_BACKEND": "",  # Defaults to django.contrib.auth.backends.ModelBackend
     "REDIRECT_AFTER_AUTH": "http://localhost:3000",
     "USE_RAPIDPRO_VIEWSET": False,
+    "REPLACE_USERNAME_CHARACTERS": "-.",  # A string of characters to replace if found within the captured username when using the `USE_EMAIL_USERNAME` functionality
+    "USERNAME_REPLACEMENT_CHARACTER": "_", # The character used to replace the characters within the `REPLACE_USERNAME_CHARACTERS` string
     # A map containing a field as a key and a map containing the regex and optional help_text strings as it's value
     # that's used to validate all field inputs retrieved for the particular key
     "FIELD_VALIDATION_REGEX": {

--- a/oidc/__init__.py
+++ b/oidc/__init__.py
@@ -2,6 +2,6 @@
 Main init file for oidc app
 """
 
-VERSION = (0, 0, 9)
+VERSION = (0, 0, 10)
 __version__ = ".".join(str(v) for v in VERSION)
 default_app_config = "oidc.apps.oidcConfig"

--- a/oidc/settings.py
+++ b/oidc/settings.py
@@ -22,6 +22,8 @@ OPENID_CONNECT_VIEWSET_CONFIG = {
             "help_text": "Username should only contain alpha numeric characters",
         }
     },
+    "REPLACE_USERNAME_CHARACTERS": "-.",
+    "USERNAME_REPLACEMENT_CHARACTER": "_",
 }
 
 OPENID_CONNECT_AUTH_SERVERS = {

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -79,6 +79,13 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             config.get("USER_UNIQUE_FILTER_FIELD")
             or default_config["USER_UNIQUE_FILTER_FIELD"]
         )
+        self.replaceable_username_characters = config.get(
+            "REPLACE_USERNAME_CHARACTERS", default_config["REPLACE_USERNAME_CHARACTERS"]
+        )
+        self.username_char_replacement = config.get(
+            "USERNAME_REPLACEMENT_CHARACTER",
+            default_config["USERNAME_REPLACEMENT_CHARACTER"],
+        )
         self.field_validation_regex = (
             config.get("FIELD_VALIDATION_REGEX")
             or default_config["FIELD_VALIDATION_REGEX"]
@@ -220,6 +227,14 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                     == 0
                 ):
                     user_data["username"] = user_data["email"].split("@")[0]
+                    if (
+                        self.replaceable_username_characters
+                        and self.username_char_replacement
+                    ):
+                        for char in list(self.replaceable_username_characters):
+                            user_data["username"] = user_data["username"].replace(
+                                char, self.username_char_replacement
+                            )
                     missing_fields.remove("username")
 
         return user_data, missing_fields

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -226,16 +226,24 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                     self.user_model.objects.filter(username__iexact=username).count()
                     == 0
                 ):
-                    user_data["username"] = user_data["email"].split("@")[0]
+                    username = user_data["email"].split("@")[0]
                     if (
                         self.replaceable_username_characters
                         and self.username_char_replacement
                     ):
                         for char in list(self.replaceable_username_characters):
-                            user_data["username"] = user_data["username"].replace(
+                            username = username.replace(
                                 char, self.username_char_replacement
                             )
-                    missing_fields.remove("username")
+
+                    # Validate retrieved username matches regex
+                    if "username" in self.field_validation_regex:
+                        regex = re.compile(
+                            self.field_validation_regex["username"].get("regex")
+                        )
+                        if regex.search(username):
+                            user_data["username"] = username
+                            missing_fields.remove("username")
 
         return user_data, missing_fields
 

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -44,6 +44,12 @@ OPENID_CONNECT_VIEWSET_CONFIG = {
     "SSO_COOKIE_DATA": "email",
     "JWT_ALGORITHM": "HS256",
     "JWT_SECRET_KEY": "abc",
+    "FIELD_VALIDATION_REGEX": {
+        "username": {
+            "regex": "^[\w\d]*$",
+            "help_text": "Username should only contain word characters & numbers i.e datatester23",
+        },
+    },
 }
 
 
@@ -293,6 +299,27 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             self.assertEqual(response.status_code, 302)
             self.assertEqual(count + 1, User.objects.all().count())
             self.assertEqual(1, User.objects.filter(username='jane_doe').count())
+
+        # Invalid characters that are not in the replacement list
+        # cause the retrieved username to be ignored & returns the
+        # user data entry form
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_func:
+            mock_func.return_value = {
+                "family_name": "hello",
+                "given_name": "jane",
+                "email": "jane.doe+hello@example.com",
+            }
+
+            data = {"id_token": "sadsdaio3209lkasdlkas0d.sdojdsiad.iosdadia"}
+            count = User.objects.all().count()
+            request = self.factory.post("/", data=data)
+            response = view(request, auth_server="default")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.template_name,
+                "oidc/oidc_user_data_entry.html")
 
     @override_settings(OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS)
     @patch(


### PR DESCRIPTION
# Changes

- Add new `REPLACEABLE_USERNAME_CHARACTERS` and `USERNAME_CHARACTER_REPLACEMENT` settings
- Add functionality to replace invalid characters from a username when using the `USE_EMAIL_USERNAME` functionality

Closes #45 #46