### PR TITLE
Switch from Deprecated ugettext

### DIFF
--- a/oidc/apps.py
+++ b/oidc/apps.py
@@ -2,7 +2,7 @@
 Application Module for oidc app
 """
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class oidcConfig(AppConfig):

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -14,7 +14,7 @@ from django.http import (
     HttpResponseBadRequest,
     HttpResponseRedirect,
 )
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import jwt
 from rest_framework import permissions, status, viewsets


### PR DESCRIPTION
django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(), ungettext(), and ungettext_lazy()  were [ deprecated since django 3.0](https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0) and [removed in 4.0](https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0)

Switch to functions that they’re aliases for