### PR TITLE
Fix README build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ona OpenID Connect Client [![Build Status](https://travis-ci.org/onaio/ona-oidc.svg?branch=master)](https://travis-ci.org/onaio/ona-oidc)
+# Ona OpenID Connect Client [![CI](https://github.com/onaio/ona-oidc/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/onaio/ona-oidc/actions/workflows/ci.yml)
 
 A pluggable django application that implements OpenID Connect client functionalities.
 


### PR DESCRIPTION
## Summary
- Replace the broken Travis badge in the README with the GitHub Actions CI badge.

## Notes
- Points to the existing `.github/workflows/ci.yml` workflow on `main`.