### PR TITLE
fix: honour FIELD_VALIDATION_REGEX in form + skip stale code re-exchange

### DIFF
--- a/oidc/client.py
+++ b/oidc/client.py
@@ -35,6 +35,31 @@ REDIRECT_AFTER_AUTH = "redirect_after_auth"
 # logs and easy to compare against IdP-side configuration.
 _AUTHORIZE_URL_SAFE_CHARS = ":/"
 
+# Cache-key prefix (`oidc:state:`) for the PKCE `state -> code_verifier`
+# entry. The raw `state` value is reflected in URLs and (on the form
+# re-submit path) also flows from the request body, so using it directly
+# as the cache key would let any caller who reaches `_clear_login_states`
+# delete arbitrary unrelated cache entries (sessions, rate-limit
+# counters, etc.). Namespacing under `oidc:state:` confines those
+# mutations to the OIDC keyspace.
+_STATE_CACHE_PREFIX = "oidc:state:"
+
+
+def state_cache_key(state: str) -> str:
+    """
+    Return the namespaced cache key (`oidc:state:<state>`) for an OIDC
+    `state` value.
+
+    Always use this helper when reading, writing, or deleting the
+    PKCE state cache entry — never compute the key inline. The raw
+    `state` value can flow from attacker-controlled request bodies
+    on the form re-submit path; routing through this prefix is what
+    prevents `_clear_login_states` from deleting unrelated cache
+    entries (Django sessions, rate-limit counters, etc.).
+    """
+    return f"{_STATE_CACHE_PREFIX}{state}"
+
+
 RESERVED_AUTHORIZE_PARAMS = frozenset(
     {
         "client_id",
@@ -365,7 +390,7 @@ class OpenIDClient:
             # at callback time.
             state = secrets.token_urlsafe(32)
             cache.set(
-                state,
+                state_cache_key(state),
                 code_verifier,
                 self.pkce_code_challenge_timeout,
             )

--- a/oidc/templates/oidc/oidc_user_data_entry.html
+++ b/oidc/templates/oidc/oidc_user_data_entry.html
@@ -11,8 +11,10 @@
             {% if error %}
             <p class="error-message">{{ error }}</p>
             {% endif %}
-            <input type="text" name="username" placeholder="Username" pattern="^[A-Za-z0-9_]*$" title="Username should not contain . @ - symbols">
+            <input type="text" name="username" placeholder="Username" pattern="{{ username_pattern }}" title="{{ username_help_text }}">
             <input type="hidden" name="id_token" value="{{ id_token }}">
+            <input type="hidden" name="state" value="{{ state|default:'' }}">
+            <input type="hidden" name="from_username_form" value="1">
             <input type="submit" value="Save">
         </form>
     </div>

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -37,6 +37,7 @@ from oidc.client import (
     NonceVerificationFailed,
     OpenIDClient,
     TokenVerificationFailed,
+    state_cache_key,
 )
 from oidc.utils import (
     email_usename_to_url_safe,
@@ -49,6 +50,22 @@ from oidc.utils import (
 
 default_config = getattr(default, "OPENID_CONNECT_VIEWSET_CONFIG", {})
 SSO_COOKIE_NAME = "SSO"
+
+# Hidden field on oidc_user_data_entry.html that signals the form is
+# re-POSTing to the callback URL. Not a security boundary — the value
+# is a public constant and can be forged. Its purpose is to make the
+# "use id_token from body, skip auth-code exchange" path deliberate
+# (only triggered by our own form), so the broader code-exchange path
+# remains the default. Real protection comes from
+# verify_and_decode_id_token (signature, expiry, nonce).
+USERNAME_FORM_MARKER_FIELD = "from_username_form"
+USERNAME_FORM_MARKER_VALUE = "1"
+
+# Defaults used when FIELD_VALIDATION_REGEX has no "username" entry.
+# Kept conservative so the rendered form matches the legacy template
+# behaviour for deployments that haven't customized validation.
+DEFAULT_USERNAME_PATTERN = r"^[A-Za-z0-9_]*$"
+DEFAULT_USERNAME_HELP_TEXT = "Username should not contain . @ - symbols"
 
 logger = logging.getLogger(__name__)
 
@@ -210,6 +227,51 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             _("Unable to process OpenID connect logout request."),
         )
 
+    def _username_field_config(self) -> Tuple[str, str]:
+        """
+        Return (regex, help_text) for the username field, falling back
+        to conservative defaults when FIELD_VALIDATION_REGEX is unset.
+        The configured regex is forwarded as-is — HTML5 `pattern` already
+        full-matches the input value implicitly, so the contract is that
+        deployers supply a single complete pattern (top-level alternation
+        with internal anchors will combine with the implicit full-match
+        the same way it does in any browser-rendered form).
+        """
+        cfg = self.field_validation_regex.get("username", {})
+        regex = cfg.get("regex") or DEFAULT_USERNAME_PATTERN
+        help_text = cfg.get("help_text") or DEFAULT_USERNAME_HELP_TEXT
+        return regex, help_text
+
+    def _username_form_response(
+        self,
+        data: dict,
+        *,
+        state: Optional[str] = None,
+        **response_kwargs,
+    ) -> Response:
+        """
+        Build a Response for oidc_user_data_entry.html with the username
+        regex/help text injected so the form's `pattern`/`title`
+        attributes always reflect the deployed FIELD_VALIDATION_REGEX
+        config, and the original auth-flow `state` rendered as a hidden
+        input so the form re-submit carries it back. Callers pass the
+        state once via the kwarg; the helper guarantees it's emitted on
+        every render so `_clear_login_states` can drop the PKCE cache
+        entry on the success path that follows.
+        """
+        regex, help_text = self._username_field_config()
+        merged = {
+            **data,
+            "username_pattern": regex,
+            "username_help_text": help_text,
+            "state": state or "",
+        }
+        return Response(
+            merged,
+            template_name="oidc/oidc_user_data_entry.html",
+            **response_kwargs,
+        )
+
     def _check_user_uniqueness(self, user_data: dict) -> Optional[str]:
         """
         Helper function that checks if the supplied user data is unique. If user_data does not
@@ -344,8 +406,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
 
         :param server_response: Response from authorization server
         """
-        if server_response.get("state"):
-            cache.delete(server_response.get("state"))
+        state = server_response.get("state")
+        if state:
+            cache.delete(state_cache_key(state))
 
     @action(methods=["POST", "GET"], detail=False)
     def callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa
@@ -354,15 +417,44 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         server_response = {}
 
         if client:
-            if client.response_mode == "form_post":
+            # The username-entry form re-POSTs to the callback URL with
+            # the original (already-consumed) ?code= still on the URL
+            # because action="" preserves the query string. Detect that
+            # specific re-submit via the hidden marker the form sets and
+            # reuse the id_token it carries instead of re-exchanging the
+            # stale code (which 400s from the IdP as invalid_code). The
+            # marker is a path gate, not an auth check — the id_token is
+            # still verified downstream.
+            is_username_form_resubmit = (
+                request.method == "POST"
+                and request.data.get(USERNAME_FORM_MARKER_FIELD)
+                == USERNAME_FORM_MARKER_VALUE
+                and request.data.get("id_token")
+            )
+            if is_username_form_resubmit:
+                # Carry `state` forward (the form rendered it as a hidden
+                # input from the original server_response) so the success
+                # path's _clear_login_states can drop the PKCE cache entry
+                # written by client.login(). Without this, that entry would
+                # leak until cache TTL on every missing-username flow.
+                server_response = {
+                    "id_token": request.data.get("id_token"),
+                    "state": request.data.get("state"),
+                }
+            elif client.response_mode == "form_post":
                 server_response = request.data
 
             elif client.response_mode == "query":
                 server_response = request.query_params
 
-            if client.use_pkce and server_response.get("state"):
-                # Get the original code verifier for PKCE flow
-                code_verifier = cache.get(server_response.get("state"))
+            state_value = server_response.get("state")
+            if client.use_pkce and state_value:
+                # Get the original code verifier for PKCE flow. We only
+                # consult the namespaced key — never the raw state value
+                # — so an attacker who reaches this branch with a
+                # chosen `state` cannot probe arbitrary keys (e.g.
+                # session IDs) for existence via cache-hit timing.
+                code_verifier = cache.get(state_cache_key(state_value))
 
                 if code_verifier is None:
                     logger.error("PKCE code verifier not found in cache")
@@ -463,8 +555,8 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                             ):
                                 data = {"id_token": id_token}
                                 logger.info("missing_fields: ", missing_fields)
-                                return Response(
-                                    data, template_name="oidc/oidc_user_data_entry.html"
+                                return self._username_form_response(
+                                    data, state=server_response.get("state")
                                 )
                             else:
                                 missing_fields = ", ".join(missing_fields)
@@ -487,8 +579,8 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                                     "error": f"{field.capitalize()} field is already in use.",
                                 }
                                 logger.info(data)
-                                return Response(
-                                    data, template_name="oidc/oidc_user_data_entry.html"
+                                return self._username_form_response(
+                                    data, state=server_response.get("state")
                                 )
 
                         self.validate_fields(user_data)
@@ -503,10 +595,10 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                     stack_trace = traceback.format_exc()
                     logger.info("ValueError")
                     logger.info(stack_trace)
-                    return Response(
+                    return self._username_form_response(
                         {"error": str(e), "id_token": id_token},
+                        state=server_response.get("state"),
                         status=status.HTTP_400_BAD_REQUEST,
-                        template_name="oidc/oidc_user_data_entry.html",
                     )
                 except jwt.exceptions.DecodeError:
                     return Response(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ from django.test.utils import override_settings
 import jwt
 import requests
 
-from oidc.client import OpenIDClient, TokenVerificationFailed
+from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
 
 OPENID_CONNECT_AUTH_SERVERS = {
     "default": {
@@ -293,7 +293,7 @@ class OpenIDClientTestCase(TestCase):
         result = client.login()
         self.assertIsInstance(result, HttpResponseRedirect)
         self.assertEqual(result.url, expected_url)
-        mock_cache_set.assert_called_once_with("123", "123", 600)
+        mock_cache_set.assert_called_once_with(state_cache_key("123"), "123", 600)
         # Two calls now: 128-byte verifier + 32-byte state.
         mock_token_urlsafe.assert_any_call(128)
         mock_token_urlsafe.assert_any_call(32)
@@ -390,7 +390,7 @@ class OpenIDClientTestCase(TestCase):
         self.assertIsInstance(result, HttpResponseRedirect)
         self.assertEqual(result.url, expected_url)
         # Default code challenge timeout is 600
-        mock_cache_set.assert_called_once_with("123", "123", 600)
+        mock_cache_set.assert_called_once_with(state_cache_key("123"), "123", 600)
 
     @override_settings(
         OPENID_CONNECT_AUTH_SERVERS={

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -15,8 +15,15 @@ import jwt
 from mock import MagicMock, patch
 from rest_framework.test import APIRequestFactory
 
-from oidc.client import OpenIDClient
-from oidc.viewsets import BaseOpenIDConnectViewset, UserModelOpenIDConnectViewset
+from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
+from oidc.viewsets import (
+    DEFAULT_USERNAME_HELP_TEXT,
+    DEFAULT_USERNAME_PATTERN,
+    USERNAME_FORM_MARKER_FIELD,
+    USERNAME_FORM_MARKER_VALUE,
+    BaseOpenIDConnectViewset,
+    UserModelOpenIDConnectViewset,
+)
 
 User = get_user_model()
 
@@ -112,6 +119,288 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             response = view(request, auth_server="default")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.template_name, "oidc/oidc_user_data_entry.html")
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_username_form_resubmit_clears_state_cache(self):
+        """
+        On a successful re-submit of the username-entry form, the cache
+        entry that client.login() wrote against the OIDC `state` value
+        must be deleted by _clear_login_states. The form carries the
+        original `state` back as a hidden input, the short-circuit
+        threads it into server_response, and cleanup runs as on the
+        non-form-render path. Without this, the entry leaks until cache
+        TTL on every missing-username flow.
+        """
+        # Prime the cache the way client.login() actually writes it
+        # (namespaced via state_cache_key).
+        state = "known-state-value"
+        cache.set(state_cache_key(state), "known-code-verifier")
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_decode:
+            mock_decode.return_value = {
+                "name": "Cache User",
+                "preferred_username": "cacheuser@example.com",
+                "given_name": "cache",
+                "family_name": "User",
+                "email": "cacheuser@example.com",
+            }
+            request = self.factory.post(
+                "/",
+                data={
+                    "id_token": "sadsdaio3209lkasdlkas0d.sdojdsiad.iosdadia",
+                    "username": "cache_chosen",
+                    "state": state,
+                    USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+                },
+            )
+            response = view(request, auth_server="default")
+            self.assertEqual(response.status_code, 302)
+            self.assertIsNone(cache.get(state_cache_key(state)))
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_form_resubmit_attacker_state_does_not_touch_unrelated_cache_entries(self):
+        """
+        Security boundary: an attacker holding a valid id_token can drive
+        the form re-submit short-circuit with an arbitrary `state` value
+        in the body. _clear_login_states must only delete entries inside
+        the OIDC `oidc:state:` keyspace, never raw keys that other apps
+        (Django sessions, rate-limit counters, feature flags, etc.) own.
+        Pins the state-cache-key namespace as the security boundary.
+        """
+        cache.set("unrelated-app-key", "important-data")
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_decode:
+            mock_decode.return_value = {
+                "name": "Attacker User",
+                "preferred_username": "attacker@example.com",
+                "given_name": "att",
+                "family_name": "Acker",
+                "email": "attacker@example.com",
+            }
+            request = self.factory.post(
+                "/",
+                data={
+                    "id_token": "sadsdaio3209lkasdlkas0d.sdojdsiad.iosdadia",
+                    "username": "att_chosen",
+                    # Attacker chooses the cache key they want deleted.
+                    "state": "unrelated-app-key",
+                    USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+                },
+            )
+            response = view(request, auth_server="default")
+            self.assertEqual(response.status_code, 302)
+            # The unrelated entry is untouched. Only the namespaced
+            # equivalent (oidc:state:unrelated-app-key) — which doesn't
+            # exist — would have been deleted.
+            self.assertEqual(cache.get("unrelated-app-key"), "important-data")
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_form_post_mode_post_with_id_token_no_marker_uses_request_data(self):
+        """
+        Symmetric to the query-mode security regression: in the default
+        response_mode=form_post, a POST that carries an `id_token` in
+        the body but NOT the form marker must follow the existing
+        `server_response = request.data` branch unchanged. The new
+        short-circuit must not alter form_post semantics for callers
+        that aren't our re-submit form (i.e., the IdP itself).
+
+        Limitation: the assertions below (`mock_exchange.assert_not_called`
+        + `mock_decode.assert_called_once_with(...)`) hold whether the
+        form_post branch or the short-circuit branch ran — both source
+        the id_token from request.data and skip the auth-code exchange.
+        This is therefore a behavioural pin, not a code-path pin.
+        """
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code"
+            ) as mock_exchange,
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+            ) as mock_decode,
+        ):
+            mock_decode.return_value = {
+                "name": "FormPost User",
+                "preferred_username": "fpuser@example.com",
+                "given_name": "fp",
+                "family_name": "User",
+                "email": "fpuser@example.com",
+            }
+            # No marker, no ?code= in URL: id_token comes from request.data
+            # via the form_post branch. Exchange must never be attempted.
+            request = self.factory.post(
+                "/",
+                data={"id_token": "idp-supplied-id-token"},
+            )
+            response = view(request, auth_server="default")
+            self.assertEqual(response.status_code, 302)
+            mock_exchange.assert_not_called()
+            mock_decode.assert_called_once_with("idp-supplied-id-token")
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_username_form_resubmit_does_not_re_exchange_code(self):
+        """
+        When the user-data-entry form re-POSTs to the callback URL, the
+        original OIDC `?code=...` is still on the URL because the form's
+        action="" preserves the query string. The viewset must NOT try to
+        re-exchange that one-shot code (which would 400 from the IdP as
+        invalid_code) — it should use the id_token already in the form
+        body. The form sends a `from_username_form=1` marker that gates
+        this short-circuit.
+        """
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code"
+            ) as mock_exchange,
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+            ) as mock_decode,
+        ):
+            mock_decode.return_value = {
+                "email_verified": False,
+                "name": "Bob User",
+                "preferred_username": "bob@example.com",
+                "given_name": "bob",
+                "family_name": "User",
+                "email": "bob@example.com",
+            }
+            request = self.factory.post(
+                "/?code=stale-already-consumed-code&state=stale-state",
+                data={
+                    "id_token": "sadsdaio3209lkasdlkas0d.sdojdsiad.iosdadia",
+                    "username": "bob_chosen",
+                    USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+                },
+            )
+            response = view(request, auth_server="default")
+            self.assertEqual(response.status_code, 302)
+            mock_exchange.assert_not_called()
+            self.assertTrue(User.objects.filter(username="bob_chosen").exists())
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "RESPONSE_MODE": "query",
+            }
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_query_mode_post_with_id_token_but_no_form_marker_uses_code_exchange(self):
+        """
+        Security regression: a POST to /callback carrying an id_token in
+        the body but WITHOUT the form marker must NOT short-circuit the
+        auth-code exchange for clients configured with response_mode=query.
+        Otherwise any holder of a signed id_token could bypass the
+        state/nonce validation tied to the auth-code flow.
+        """
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code"
+            ) as mock_exchange,
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+            ) as mock_decode,
+        ):
+            # Make the exchange fail so we don't accidentally exercise
+            # the rest of the flow. We pin two invariants:
+            #   1. The code from the URL IS exchanged.
+            #   2. The id_token from the body is NEVER decoded.
+            mock_exchange.side_effect = TokenVerificationFailed("test stop")
+            request = self.factory.post(
+                "/?code=fresh-code-from-idp",
+                data={"id_token": "attacker-supplied-id-token"},
+            )
+            response = view(request, auth_server="default")
+            mock_exchange.assert_called_once()
+            self.assertEqual(mock_exchange.call_args[0][0], "fresh-code-from-idp")
+            for call in mock_decode.call_args_list:
+                self.assertNotIn("attacker-supplied-id-token", call.args)
+            self.assertEqual(response.status_code, 401)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            # Disable email-derived username so the missing-username
+            # path actually renders the form (instead of auto-deriving
+            # a value the permissive regex below would happily accept).
+            "USE_EMAIL_USERNAME": False,
+            "FIELD_VALIDATION_REGEX": {
+                "username": {
+                    "regex": r"(?!^\d+$)^.+$",
+                    "help_text": "Custom validation help",
+                },
+            },
+        }
+    )
+    def test_username_form_pattern_and_title_come_from_config(self):
+        """
+        The form's HTML5 `pattern` and `title` attributes must reflect
+        the configured FIELD_VALIDATION_REGEX["username"]["regex"] and
+        ["help_text"], not the legacy hard-coded `^[A-Za-z0-9_]*$`.
+        Otherwise a deployment with a permissive regex sees its
+        prefill rejected by the browser even though the server-side
+        validator would accept it.
+        """
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_func:
+            mock_func.return_value = {
+                "family_name": "bob",
+                "given_name": "just bob",
+                "email": "bob@example.com",
+            }
+            data = {"id_token": "sadsdaio3209lkasdlkas0d.sdojdsiad.iosdadia"}
+            request = self.factory.post("/", data=data)
+            response = view(request, auth_server="default")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.template_name, "oidc/oidc_user_data_entry.html")
+            # The configured regex is forwarded as-is; HTML5 `pattern`
+            # already implicitly full-matches the input value.
+            self.assertEqual(response.data["username_pattern"], r"(?!^\d+$)^.+$")
+            self.assertEqual(
+                response.data["username_help_text"], "Custom validation help"
+            )
+
+    def test_username_field_config_falls_back_to_defaults(self):
+        """
+        When FIELD_VALIDATION_REGEX has no `username` entry, the helper
+        falls back to the module-level defaults so the rendered template
+        keeps its legacy behaviour for deployments that haven't
+        customized validation.
+        """
+        viewset = BaseOpenIDConnectViewset()
+        viewset.field_validation_regex = {}
+        regex, help_text = viewset._username_field_config()
+        self.assertEqual(regex, DEFAULT_USERNAME_PATTERN)
+        self.assertEqual(help_text, DEFAULT_USERNAME_HELP_TEXT)
+
+    def test_username_form_template_uses_marker_constants(self):
+        """
+        The form template hard-codes the marker field name and value;
+        the viewset reads them via constants. Pin that the two stay
+        in sync — a rename in viewsets.py without a template update
+        (or vice versa) silently breaks the form-resubmit gate.
+        """
+        from django.template.loader import render_to_string
+
+        rendered = render_to_string(
+            "oidc/oidc_user_data_entry.html",
+            {
+                "id_token": "tok",
+                "username_pattern": "^test$",
+                "username_help_text": "test help",
+            },
+        )
+        self.assertIn(f'name="{USERNAME_FORM_MARKER_FIELD}"', rendered)
+        self.assertIn(f'value="{USERNAME_FORM_MARKER_VALUE}"', rendered)
 
     @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
     def test_create_user_providing_id_token_in_form(self):
@@ -338,10 +627,12 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             request = self.factory.post("/", data=data)
             response = view(request, auth_server="default")
             self.assertEqual(response.status_code, 400)
-            self.assertTrue(
-                response.rendered_content.startswith(
-                    b'{"error":"Username should only contain word characters & numbers and should have 3 or more characters"'
-                )
+            # Don't pin JSON key order — the helper that builds this
+            # response merges in extra context keys (username_pattern,
+            # username_help_text), so the error key may not be first.
+            self.assertIn(
+                b'"error":"Username should only contain word characters & numbers and should have 3 or more characters"',
+                response.rendered_content,
             )
             self.assertEqual(response.template_name, "oidc/oidc_user_data_entry.html")
 
@@ -1053,11 +1344,12 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         }
         mock_retrieve_tokens_using_auth_code.return_value = {"id_token": "id_token"}
         view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
-        # Simulate the code verifier being in the cache
-        code_verifier_cache_key = "pkce_123"
-        cache.set(code_verifier_cache_key, "123")
+        # Simulate the code verifier being in the cache, namespaced the
+        # way client.login() writes it.
+        state = "pkce_123"
+        cache.set(state_cache_key(state), "123")
 
-        data = {"state": code_verifier_cache_key, "code": "auth_code"}
+        data = {"state": state, "code": "auth_code"}
         request = self.factory.post("/", data=data)
         response = view(request, auth_server="pkce")
 
@@ -1071,7 +1363,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             "auth_code", code_verifier="123"
         )
         # Code verifier is removed from cache
-        self.assertIsNone(cache.get(code_verifier_cache_key))
+        self.assertIsNone(cache.get(state_cache_key(state)))
 
     @override_settings(
         OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
@@ -1097,11 +1389,12 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         }
         mock_retrieve_tokens_using_auth_code.return_value = {"id_token": "id_token"}
         view = UserModelOpenIDConnectViewset.as_view({"get": "callback"})
-        # Simulate the code verifier being in the cache
-        code_verifier_cache_key = "pkce_123"
-        cache.set(code_verifier_cache_key, "123")
+        # Simulate the code verifier being in the cache, namespaced the
+        # way client.login() writes it.
+        state = "pkce_123"
+        cache.set(state_cache_key(state), "123")
 
-        data = {"state": code_verifier_cache_key, "code": "auth_code"}
+        data = {"state": state, "code": "auth_code"}
         request = self.factory.get("/", data=data)
         response = view(request, auth_server="pkce")
         self.assertEqual(response.status_code, 302)
@@ -1114,7 +1407,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             "auth_code", code_verifier="123"
         )
         # Code verifier is removed from cache
-        self.assertIsNone(cache.get(code_verifier_cache_key))
+        self.assertIsNone(cache.get(state_cache_key(state)))
 
     @override_settings(
         OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
@@ -1215,12 +1508,13 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         }
         mock_retrieve_tokens_using_auth_code.return_value = {"id_token": "id_token"}
 
-        # Simulate the cached code verifier
-        state_key = "pkce_123"
-        cache.set(state_key, "123")
+        # Simulate the cached code verifier (namespaced as client.login()
+        # would write it).
+        state = "pkce_123"
+        cache.set(state_cache_key(state), "123")
 
         view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
-        data = {"state": state_key, "code": "auth_code"}
+        data = {"state": state, "code": "auth_code"}
         request = self.factory.post("/", data=data)
         response = view(request, auth_server="pkce")
 
@@ -1230,7 +1524,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             response.data["error"],
             "The request is not authorized. Please contact the administrator.",
         )
-        self.assertIsNone(cache.get(state_key))
+        self.assertIsNone(cache.get(state_cache_key(state)))
 
     def _callback_cookie(self, mock_verify, mock_encode):
         mock_verify.return_value = {


### PR DESCRIPTION
## Summary

Two pre-existing bugs in the missing-username form flow on `oidc/templates/oidc/oidc_user_data_entry.html` + `oidc.viewsets.BaseOpenIDConnectViewset.callback`. Both surfaced while exploring an unrelated feature on #118 (now closed); these fixes are independent of that feature and worth landing on their own.

## Bugs fixed

### 1. Form ignores `FIELD_VALIDATION_REGEX` for HTML5 `pattern` / `title` — fixes #119

The form template hard-coded `pattern="^[A-Za-z0-9_]*$"` regardless of `FIELD_VALIDATION_REGEX["username"]`. Deployments with a custom username regex got browser validation that disagreed with server-side validation.

**Fix:** drive `pattern` / `title` from the configured regex via a new `_username_field_config()` helper, with module-level `DEFAULT_USERNAME_PATTERN` / `DEFAULT_USERNAME_HELP_TEXT` as fallbacks. A new `_username_form_response()` helper is the single render site so the three callers (missing-username, uniqueness conflict, `ValueError`) cannot drift.

### 2. Form re-POST re-exchanges already-consumed auth code — fixes #120

The form's `action=""` preserves the original `?code=...` query string. In `response_mode=query` the viewset re-ran `retrieve_tokens_using_auth_code` with the stale code, and the IdP responded with `invalid_code`.

**Fix:** add a hidden `from_username_form=1` marker. When present on a POST, source `id_token` from `request.data` and skip the auth-code exchange. The marker is a path gate, not an auth boundary — `verify_and_decode_id_token` (signature, expiry, nonce) is unchanged. A regression test pins that a POST carrying an `id_token` but no marker still goes through the normal auth-code exchange in query mode, so a forged marker can't bypass state/nonce protection.

## While here

- **State threading.** The form now carries the original auth-flow `state` as a hidden input, and `_username_form_response` accepts a `state` kwarg that all callers thread through. On the success path that follows, `_clear_login_states` drops the PKCE cache entry — previously it silently no-op'd because the synthesised `server_response` had no `state`, leaking the entry until cache TTL on every missing-username flow.
- **State cache namespacing.** Cache keys for the PKCE `state -> code_verifier` entry are now wrapped with a new `state_cache_key()` helper that prefixes them with `oidc:state:`. Without this, an attacker holding any valid `id_token` for the configured client could drive the form-resubmit short-circuit (or the pre-existing `response_mode=form_post` path) with a chosen `state` value, and `_clear_login_states`'s `cache.delete(state)` would land on an unrelated key — Django sessions, rate-limit counters, feature-flag cache, anything else co-located in the cache backend.

### A note on the cache-key migration

The namespace change rewrites the layout of the OIDC state cache. PKCE logins that are mid-flight at the moment this version deploys (state cached pre-deploy under the un-namespaced key, callback hits post-deploy expecting `oidc:state:<state>`) will fail with the existing `PKCE code verifier not found in cache` 401, and the user just retries.

An earlier iteration of this PR added a transitional fallback that read the legacy un-namespaced key when the namespaced lookup missed. **That fallback was removed** because:

1. The deploy window is naturally bounded by `PKCE_CODE_CHALLENGE_TIMEOUT` (default 600s). Every pre-deploy state entry is gone within ~10 minutes; carrying transitional code longer than that is dead weight.
2. The fallback re-introduced an un-namespaced `cache.get(<attacker-controlled state>)` against the same key space the namespacing was meant to protect, opening a small read-side oracle (an attacker can distinguish "no entry" from "some entry" via downstream IdP-exchange error variance). Keeping the security boundary tight outweighs the brief in-flight breakage.

Operators concerned about that ~10-minute window can drain traffic before deploying or restart with empty cache. For routine deploys, the cost is trivial and the security boundary stays clean.

## Test plan

- [x] `pattern` / `title` reflect FIELD_VALIDATION_REGEX (and fall back to defaults).
- [x] Form re-submit does not re-exchange the stale code.
- [x] Security regression: query-mode POST + id_token without marker still uses the auth-code exchange.
- [x] Symmetric form_post-mode test for missing-marker behaviour (documented as a behavioural pin, not a code-path pin).
- [x] Form re-submit success clears the namespaced state cache entry.
- [x] Security regression: attacker-controlled `state` cannot delete entries outside the `oidc:state:` namespace.
- [x] Marker constants stay in sync between viewset and template.
- [x] `tox -e py311-django52`: 103/103 green.
- [x] `tox -e lint`: clean.
