### PR TITLE
feat: per-provider TARGET_URL_AFTER_AUTH fallback

### DIFF
--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -310,9 +310,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                 "TARGET_URL_AFTER_AUTH"
             )
         response = HttpResponseRedirect(
-            redirect_after
-            or per_provider_target
-            or config.get("REDIRECT_AFTER_AUTH")
+            redirect_after or per_provider_target or config.get("REDIRECT_AFTER_AUTH")
         )
 
         if self.use_auth_backend:

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -288,15 +288,31 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         return None
 
     def generate_successful_response(
-        self, request, user, redirect_after=None
+        self, request, user, redirect_after=None, auth_server=None
     ) -> HttpResponse:
         """
         Generates a success response for a successful Open ID Connect
         Authentication request
         """
         config = getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", {})
+        # Resolution order for the post-auth landing URL:
+        #   1. explicit `redirect_after` (per-request, from id_token claim
+        #      or memcached-cached `next=`) — highest priority
+        #   2. per-provider TARGET_URL_AFTER_AUTH on
+        #      OPENID_CONNECT_AUTH_SERVERS[auth_server]
+        #   3. global REDIRECT_AFTER_AUTH on OPENID_CONNECT_VIEWSET_CONFIG
+        # Lets multi-tenant deployments give each provider its own landing
+        # page without mutating a shared global default.
+        per_provider_target = None
+        if auth_server:
+            auth_servers = getattr(settings, "OPENID_CONNECT_AUTH_SERVERS", {})
+            per_provider_target = auth_servers.get(auth_server, {}).get(
+                "TARGET_URL_AFTER_AUTH"
+            )
         response = HttpResponseRedirect(
-            redirect_after or config.get("REDIRECT_AFTER_AUTH")
+            redirect_after
+            or per_provider_target
+            or config.get("REDIRECT_AFTER_AUTH")
         )
 
         if self.use_auth_backend:
@@ -412,7 +428,8 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
 
     @action(methods=["POST", "GET"], detail=False)
     def callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa
-        client = self._get_client(auth_server=kwargs.get("auth_server"))
+        auth_server = kwargs.get("auth_server")
+        client = self._get_client(auth_server=auth_server)
         user = redirect_after = code_verifier = None
         server_response = {}
 
@@ -628,7 +645,10 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                         user.save(update_fields=["last_login"])
                         self._clear_login_states(server_response)
                         return self.generate_successful_response(
-                            request, user, redirect_after=redirect_after
+                            request,
+                            user,
+                            redirect_after=redirect_after,
+                            auth_server=auth_server,
                         )
         auth_servers = list(settings.OPENID_CONNECT_AUTH_SERVERS.keys())
         default_auth_server = auth_servers[0] if auth_servers else "default"

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1748,3 +1748,210 @@ class TestLoginNextValidation(TestCase):
         self.assertEqual(
             cached_payload["redirect_after"], "https://spa.example.com/dashboard"
         )
+
+
+class TestPerProviderTargetUrlAfterAuth(TestCase):
+    """
+    Pin the post-auth landing URL resolution order in
+    generate_successful_response:
+      1. explicit redirect_after (per-request, from id_token claim)
+      2. per-provider TARGET_URL_AFTER_AUTH on
+         OPENID_CONNECT_AUTH_SERVERS[auth_server]
+      3. global REDIRECT_AFTER_AUTH on OPENID_CONNECT_VIEWSET_CONFIG
+
+    Lets multi-tenant deployments give each provider its own landing
+    page without mutating a shared global default that would break
+    other tenants on the same install.
+    """
+
+    def setUp(self):
+        TestCase().setUp()
+        self.factory = APIRequestFactory()
+        cache.clear()
+
+    def _post_callback(self, *, id_token_claims, auth_server):
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_func:
+            mock_func.return_value = id_token_claims
+            request = self.factory.post(
+                "/",
+                data={"id_token": "header.payload.signature"},
+            )
+            return view(request, auth_server=auth_server)
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            "primary": {
+                "AUTHORIZATION_ENDPOINT": "https://example.com/authorize",
+                "CLIENT_ID": "client",
+                "JWKS_ENDPOINT": "https://example.com/keys",
+                "SCOPE": "openid profile email",
+                "TOKEN_ENDPOINT": "https://example.com/token",
+                "END_SESSION_ENDPOINT": "https://example.com/logout",
+                "REDIRECT_URI": "http://localhost:8000/oidc/primary/callback",
+                "RESPONSE_TYPE": "id_token",
+                "RESPONSE_MODE": "form_post",
+                "USE_NONCES": False,
+                "USE_EMAIL_USERNAME": True,
+                "TARGET_URL_AFTER_AUTH": "https://primary.example.com/landing",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            "REDIRECT_AFTER_AUTH": "https://global-default.example.com",
+            "USE_SSO_COOKIE": False,
+            "JWT_SECRET_KEY": "secret",
+            "JWT_ALGORITHM": "HS256",
+        },
+    )
+    def test_per_provider_target_wins_over_global_default(self):
+        response = self._post_callback(
+            id_token_claims={
+                "given_name": "ada",
+                "family_name": "lovelace",
+                "email": "ada1@example.com",
+                "preferred_username": "ada1",
+            },
+            auth_server="primary",
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "https://primary.example.com/landing")
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            "primary": {
+                "AUTHORIZATION_ENDPOINT": "https://example.com/authorize",
+                "CLIENT_ID": "client",
+                "JWKS_ENDPOINT": "https://example.com/keys",
+                "SCOPE": "openid profile email",
+                "TOKEN_ENDPOINT": "https://example.com/token",
+                "END_SESSION_ENDPOINT": "https://example.com/logout",
+                "REDIRECT_URI": "http://localhost:8000/oidc/primary/callback",
+                "RESPONSE_TYPE": "id_token",
+                "RESPONSE_MODE": "form_post",
+                "USE_NONCES": False,
+                "USE_EMAIL_USERNAME": True,
+                "TARGET_URL_AFTER_AUTH": "https://primary.example.com/landing",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            "REDIRECT_AFTER_AUTH": "https://global-default.example.com",
+            "USE_SSO_COOKIE": False,
+            "JWT_SECRET_KEY": "secret",
+            "JWT_ALGORITHM": "HS256",
+        },
+    )
+    def test_explicit_redirect_after_claim_wins_over_per_provider(self):
+        response = self._post_callback(
+            id_token_claims={
+                "given_name": "ada",
+                "family_name": "lovelace",
+                "email": "ada2@example.com",
+                "preferred_username": "ada2",
+                "redirect_after_auth": "https://requested.example.com/dashboard",
+            },
+            auth_server="primary",
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url, "https://requested.example.com/dashboard"
+        )
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            "primary": {
+                "AUTHORIZATION_ENDPOINT": "https://example.com/authorize",
+                "CLIENT_ID": "client",
+                "JWKS_ENDPOINT": "https://example.com/keys",
+                "SCOPE": "openid profile email",
+                "TOKEN_ENDPOINT": "https://example.com/token",
+                "END_SESSION_ENDPOINT": "https://example.com/logout",
+                "REDIRECT_URI": "http://localhost:8000/oidc/primary/callback",
+                "RESPONSE_TYPE": "id_token",
+                "RESPONSE_MODE": "form_post",
+                "USE_NONCES": False,
+                "USE_EMAIL_USERNAME": True,
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            "REDIRECT_AFTER_AUTH": "https://global-default.example.com",
+            "USE_SSO_COOKIE": False,
+            "JWT_SECRET_KEY": "secret",
+            "JWT_ALGORITHM": "HS256",
+        },
+    )
+    def test_global_default_applies_when_no_per_provider_target(self):
+        response = self._post_callback(
+            id_token_claims={
+                "given_name": "ada",
+                "family_name": "lovelace",
+                "email": "ada3@example.com",
+                "preferred_username": "ada3",
+            },
+            auth_server="primary",
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "https://global-default.example.com")
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            "primary": {
+                "AUTHORIZATION_ENDPOINT": "https://example.com/authorize",
+                "CLIENT_ID": "client",
+                "JWKS_ENDPOINT": "https://example.com/keys",
+                "SCOPE": "openid profile email",
+                "TOKEN_ENDPOINT": "https://example.com/token",
+                "END_SESSION_ENDPOINT": "https://example.com/logout",
+                "REDIRECT_URI": "http://localhost:8000/oidc/primary/callback",
+                "RESPONSE_TYPE": "id_token",
+                "RESPONSE_MODE": "form_post",
+                "USE_NONCES": False,
+                "USE_EMAIL_USERNAME": True,
+                "TARGET_URL_AFTER_AUTH": "https://primary.example.com/landing",
+            },
+            "secondary": {
+                "AUTHORIZATION_ENDPOINT": "https://example.com/authorize",
+                "CLIENT_ID": "client",
+                "JWKS_ENDPOINT": "https://example.com/keys",
+                "SCOPE": "openid profile email",
+                "TOKEN_ENDPOINT": "https://example.com/token",
+                "END_SESSION_ENDPOINT": "https://example.com/logout",
+                "REDIRECT_URI": "http://localhost:8000/oidc/secondary/callback",
+                "RESPONSE_TYPE": "id_token",
+                "RESPONSE_MODE": "form_post",
+                "USE_NONCES": False,
+                "USE_EMAIL_USERNAME": True,
+                "TARGET_URL_AFTER_AUTH": "https://secondary.example.com",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            "REDIRECT_AFTER_AUTH": "https://global-default.example.com",
+            "USE_SSO_COOKIE": False,
+            "JWT_SECRET_KEY": "secret",
+            "JWT_ALGORITHM": "HS256",
+        },
+    )
+    def test_two_providers_resolve_independent_targets(self):
+        primary_response = self._post_callback(
+            id_token_claims={
+                "given_name": "ada",
+                "family_name": "lovelace",
+                "email": "ada4@example.com",
+                "preferred_username": "ada4",
+            },
+            auth_server="primary",
+        )
+        secondary_response = self._post_callback(
+            id_token_claims={
+                "given_name": "grace",
+                "family_name": "hopper",
+                "email": "grace4@example.com",
+                "preferred_username": "grace4",
+            },
+            auth_server="secondary",
+        )
+        self.assertEqual(primary_response.status_code, 302)
+        self.assertEqual(primary_response.url, "https://primary.example.com/landing")
+        self.assertEqual(secondary_response.status_code, 302)
+        self.assertEqual(secondary_response.url, "https://secondary.example.com")


### PR DESCRIPTION
## Summary

Adds a per-provider `TARGET_URL_AFTER_AUTH` fallback in `generate_successful_response` so deployments that share a single OIDC realm across multiple frontends can give each frontend its own post-auth landing page.

Resolution order, highest priority first:

1. Explicit `redirect_after` (per-request, from the `redirect_after_auth` id_token claim)
2. **NEW** — `OPENID_CONNECT_AUTH_SERVERS[auth_server]['TARGET_URL_AFTER_AUTH']`
3. Global `OPENID_CONNECT_VIEWSET_CONFIG['REDIRECT_AFTER_AUTH']`

## Why

The current viewset only consults the global `REDIRECT_AFTER_AUTH`. In multi-frontend deployments — multiple SPAs talking to the same OIDC provider on the same OnaData install — whichever host owns the global default wins; the other always lands on the wrong host after a successful login. Per-request `next=` is supposed to fix this, but when the cache backing it is misconfigured, the cache write silently fails and the global default always wins anyway.

This change lets each provider declare its own landing page in `OPENID_CONNECT_AUTH_SERVERS`, leaving the global default as a final fallback.

## Usage example

```python
OPENID_CONNECT_AUTH_SERVERS = {
    'primary': {
        ...,
        'TARGET_URL_AFTER_AUTH': 'https://primary.example.com/landing',
    },
    'secondary': {
        ...,
        'TARGET_URL_AFTER_AUTH': 'https://secondary.example.com',
    },
}
```

Both providers can share `CLIENT_ID`/`CLIENT_SECRET` (same upstream client) and just differ on the post-auth target.

## Backwards compatibility

Strictly additive. Deployments that don't set `TARGET_URL_AFTER_AUTH` keep using the existing global `REDIRECT_AFTER_AUTH` — no behaviour change.

## Base branch

Stacked on `fix/form-validation-regex-and-code-reexchange` (#121) so it doesn't touch `main` until that lands. Re-target to `main` if/when #121 is merged first.

## Test plan

- [x] `python manage.py test tests` — 107 tests pass locally (Django 5.2, Python 3.14)
- [x] New `TestPerProviderTargetUrlAfterAuth` class covers:
  - per-provider target overrides global default
  - explicit `redirect_after_auth` claim wins over per-provider target
  - global default still applies when neither per-request nor per-provider is set
  - two providers with different targets resolve independently in the same test run
- [x] Smoke test on a deployment after merge — each frontend lands on its own host