### PR TITLE
feat(oidc): Keycloak Account REST proxy(sessions/linked accounts/credentials)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ INSTALLED_APPS = [
 
 ```
 
+The username-entry form and the error page extend `base.html`, and the
+package ships a plain one so a fresh install renders. To use your own,
+put it on `TEMPLATES["DIRS"]` or in an app listed before `oidc`; it only
+needs `title` and `content` blocks.
+
 1. Set `OPENID_CONNECT_VIEWSET_CONFIG` and `OPENID_CONNECT_AUTH_SERVERS` settings
 
 ```python

--- a/README.md
+++ b/README.md
@@ -326,15 +326,20 @@ choices stop being neutral:
   Pairing that backend with a proxy-enabled viewset is a deploy check
   (`oidc.E001`), so `manage.py check` fails rather than the first user who
   tries to sign in; the viewset also refuses at request time as a backstop.
-  Viewsets that keep only the id_token (which the browser already holds)
-  are unaffected.
+  The check resolves the viewset through `VIEWSET_CLASS`, so a project that
+  routes the viewset from a hand-written URLconf instead is covered only by
+  that request-time backstop. Viewsets that keep only the id_token (which
+  the browser already holds) are unaffected.
 * **The session id is rotated when the tokens are written.** Django's
   `login()` would do this, but only runs under `USE_AUTH_BACKEND`, so the
   proxy calls `cycle_key()` itself — otherwise a planted session id would
   end up holding the victim's tokens.
 
 Outbound calls to the IdP carry a `(connect, read)` timeout, default
-`(5, 15)`, configurable per auth server:
+`(5, 15)`, configurable per auth server. It must be a two-item pair or a
+single number — a list from JSON/YAML settings and a string from an env
+var are both coerced; `None` is refused, since that is `requests`' "wait
+forever":
 
 ```python
 OPENID_CONNECT_AUTH_SERVERS = {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A pluggable django application that implements OpenID Connect client functionali
 pip install -e git+https://github.com/onaio/ona-oidc.git#egg=ona-oidc
 ```
 
-2. Add `oidc` to the list of `INSTALLED_APPS`
+1. Add `oidc` to the list of `INSTALLED_APPS`
 
 ```python
 ...
@@ -25,7 +25,7 @@ INSTALLED_APPS = [
 
 ```
 
-3. Set `OPENID_CONNECT_VIEWSET_CONFIG` and `OPENID_CONNECT_AUTH_SERVERS` settings
+1. Set `OPENID_CONNECT_VIEWSET_CONFIG` and `OPENID_CONNECT_AUTH_SERVERS` settings
 
 ```python
 ...
@@ -53,7 +53,7 @@ OPENID_CONNECT_VIEWSET_CONFIG = {
     "AUTH_BACKEND": "",  # Defaults to django.contrib.auth.backends.ModelBackend
     "REDIRECT_AFTER_AUTH": "http://localhost:3000",
     "USE_RAPIDPRO_VIEWSET": False,
-    "REPLACE_USERNAME_CHARACTERS": "-.",  # A string of characters to replace if found within the captured username when using the `USE_EMAIL_USERNAME` functionality
+    "REPLACE_USERNAME_CHARACTERS": "-.",  # characters to replace in the captured username when using `USE_EMAIL_USERNAME`
     "USERNAME_REPLACEMENT_CHARACTER": "_", # The character used to replace the characters within the `REPLACE_USERNAME_CHARACTERS` string
     # A map containing a field as a key and a map containing the regex and optional help_text strings as it's value
     # that's used to validate all field inputs retrieved for the particular key
@@ -189,10 +189,11 @@ key — no IdP-side nonce verification is performed.
 ### Keycloak Account REST proxy (`ACCOUNT_ENDPOINT`)
 
 The account-proxy actions (sessions, linked accounts, credentials) forward
-to Keycloak's Account REST API, and are read-and-revoke only — there is no
-profile-update endpoint. Being Keycloak-specific, they live in
-`KeycloakAccountMixin` rather than in the base viewset, and a deployment
-opts in by routing to a viewset that mixes them in:
+to Keycloak's Account REST API, and are read-and-revoke only (there is no
+profile-update endpoint). Being Keycloak-specific, they live in
+`KeycloakAccountMixin` rather than in the base viewset
+(`BaseOpenIDConnectViewset`), and a deployment opts in by routing to a
+viewset that mixes them in:
 
 ```python
 # Ready-made: the default viewset plus the proxy.
@@ -225,25 +226,22 @@ OPENID_CONNECT_AUTH_SERVERS = {
 
 The setting is optional; with the mixin in place but `ACCOUNT_ENDPOINT`
 unset, the proxy actions return `503`. Calls are made with the signed-in user's own `access_token`, so
-they need the `manage-account` role — granted to every realm user by
+they need the `manage-account` role which is granted to every realm user by
 default.
 
-The proxy also requires a **token-producing flow**: the access/refresh
-pair it spends is only ever obtained by the authorization-code exchange
-at callback time. That means, for the auth server used with the proxy:
+The proxy calls Keycloak with the user's access token, and the only way to
+obtain one is the authorization-code exchange at callback time. The auth
+server it runs against therefore needs two settings:
 
-* `RESPONSE_TYPE: "code"` — the repository default is `"id_token"`
-  (implicit flow), which returns an id_token only. With it, login works
-  but nothing is stashed, and every proxy action answers `401` even
-  though `ACCOUNT_ENDPOINT` is set — a symptom worth recognising.
-* `TOKEN_ENDPOINT` set — used for the code exchange and again for the
-  refresh-on-401 retry. Unset, it breaks the callback itself: the exchange
-  posts to `None` and the login ends on the `401` error page, so you never
-  reach the proxy. The `503` case is the refresh path only.
-
-A hybrid `RESPONSE_TYPE` such as `"code id_token"` does not work either —
-the callback short-circuits the code exchange whenever an `id_token` is
-already present, so no access token is ever obtained.
+- `RESPONSE_TYPE: "code"`. The repository default is `"id_token"`, which
+  returns no access token: login still succeeds, but nothing is stashed
+  and every proxy action answers `401` despite a correct
+  `ACCOUNT_ENDPOINT`. Hybrid values like `"code id_token"` fail the same
+  way, because the callback skips the exchange whenever an `id_token` is
+  already present.
+- `TOKEN_ENDPOINT`, used for that exchange and again for the
+  refresh-on-`401` retry. Unset, login itself fails and you never reach
+  the proxy; it only surfaces as a proxy `503` on the refresh path.
 
 These routes take identity from the OIDC tokens in `request.session`
 rather than `request.user`, and so run with DRF authentication
@@ -276,70 +274,21 @@ tokens. They are therefore stored under provider-scoped session keys —
 `oidc_access_token:<auth_server>`, `oidc_refresh_token:<auth_server>` and
 `oidc_id_token:<auth_server>` — rather than one global name.
 
-This matters only in multi-provider deployments, where a single global key
-would be readable from *every* provider's route: a request to provider B
-would spend provider A's access token against B's account endpoint and,
-because B answers a foreign token with `401` (which the retry path reads as
-"expired"), go on to POST A's long-lived refresh token to B's token
-endpoint. Logout would likewise replay A's `id_token` to B as
-`id_token_hint`. Scoping makes those unrepresentable rather than merely
-checked.
+`logout` clears this provider's keys; other providers' tokens are
+untouched.
 
-There is deliberately no fallback read of the old un-scoped keys — that
-would reinstate the cross-provider path. Sessions established before this
-change get one `401` and sign in again, the same fallback sessions
-predating the token stash already hit.
-
-`logout` clears all three of this provider's keys before redirecting to
-the end-session endpoint. That redirect may never be completed — closed
-tab, declined confirm screen, unreachable IdP — so it is the only point
-in the flow the server controls; leaving the pair behind would let a
-logged-out session keep calling the account proxy as the user. Other
-providers' tokens are untouched, since logout is per-provider.
-
-The tokens are also only written once the login is *accepted*. The IdP
-vouching for a user is not the platform accepting them — the callback can
-still refuse (`AUTO_CREATE_USER` off, required claims missing, validation
-failures) — so nothing touches the session until the success exit. A
-refused caller's session therefore gets a `401` from the proxy, and no
-credential is left at rest for a caller who, never having signed in, will
-never log out to clear it.
-
-One flow needs more than that: when the claims carry no usable username
-the callback answers with an entry form, and the browser re-POSTs only
-the `id_token` — so the access/refresh pair obtained by the first request
-is parked in `<name>:<auth_server>:pending` until the resubmit. Those
-slots are written on that path alone. The parked pair is tagged with the
-`id_token` it belongs to and handed back only on a match, because one
-session can be running two logins at once (two tabs): pairing one login's
-`id_token` with another's tokens would sign the browser in as one
-identity while the proxy acted on the other's Keycloak account. A
-mismatch is dropped, so login completes and the proxy answers `401` until
-the next full sign-in.
-
-Because that session now carries a refresh token, two Django-level
-choices stop being neutral:
-
-* **A server-side `SESSION_ENGINE` is required.** Signed-cookie sessions
-  are signed but not encrypted — the contents are client-readable and stay
-  replayable after logout, since there is no server-side record to delete.
-  Pairing that backend with a proxy-enabled viewset is a deploy check
-  (`oidc.E001`), so `manage.py check` fails rather than the first user who
-  tries to sign in; the viewset also refuses at request time as a backstop.
-  The check resolves the viewset through `VIEWSET_CLASS`, so a project that
-  routes the viewset from a hand-written URLconf instead is covered only by
-  that request-time backstop. Viewsets that keep only the id_token (which
-  the browser already holds) are unaffected.
-* **The session id is rotated when the tokens are written.** Django's
-  `login()` would do this, but only runs under `USE_AUTH_BACKEND`, so the
-  proxy calls `cycle_key()` itself — otherwise a planted session id would
-  end up holding the victim's tokens.
+Because that session carries a refresh token, a **server-side
+`SESSION_ENGINE` is required** — signed-cookie sessions are not encrypted.
+A deploy check (`oidc.E001`) fails `manage.py check` when the two are
+paired, and the viewset refuses at request time as a backstop. The check
+resolves the viewset through `VIEWSET_CLASS`, so a project routing it from
+a hand-written URLconf gets only the backstop. Viewsets that keep just the
+id_token are unaffected. The session id is also rotated when the tokens
+are written.
 
 Outbound calls to the IdP carry a `(connect, read)` timeout, default
 `(5, 15)`, configurable per auth server. It must be a two-item pair or a
-single number — a list from JSON/YAML settings and a string from an env
-var are both coerced; `None` is refused, since that is `requests`' "wait
-forever":
+single number; `None` is refused:
 
 ```python
 OPENID_CONNECT_AUTH_SERVERS = {
@@ -352,7 +301,7 @@ OPENID_CONNECT_AUTH_SERVERS = {
 
 `logout` also removes the pre-namespacing `oidc_id_token` /
 `oidc_access_token` / `oidc_refresh_token` keys. That is a write-side
-sweep only — it does not reinstate the fallback *read*, so it cannot
+sweep only — it does not reinstate the fallback _read_, so it cannot
 bring back the cross-provider path. Without it, a token stashed before
 the rename would outlive every sign-out, since the session is flushed
 only under `USE_AUTH_BACKEND`.
@@ -363,7 +312,7 @@ The trusted-host set is `LOGIN_REDIRECT_ALLOWED_HOSTS` plus the request's
 own host, so both the `next` validation and the account-proxy `Origin`
 check inherit their strength from Django's `ALLOWED_HOSTS`:
 
-* **Scope `ALLOWED_HOSTS` to the hosts you serve.** The request host is
+- **Scope `ALLOWED_HOSTS` to the hosts you serve.** The request host is
   read via `request.get_host()`, which Django rejects with a `400`
   unless it matches `ALLOWED_HOSTS`. That validation is what keeps an
   attacker-supplied `Host` out of the trusted set. With
@@ -371,7 +320,7 @@ check inherit their strength from Django's `ALLOWED_HOSTS`:
   echoed back verbatim, and both checks degrade to comparing one
   request header against another.
 
-* **With `USE_X_FORWARDED_HOST = True`, the proxy must strip any
+- **With `USE_X_FORWARDED_HOST = True`, the proxy must strip any
   client-supplied `X-Forwarded-Host`.** Django prefers that header over
   `Host`, and unlike `Host` a page can set it on a `fetch`. A proxy that
   forwards it lets a caller nominate its own origin as trusted.
@@ -401,7 +350,7 @@ subclass enforces.
 `USE_RAPIDPRO_VIEWSET` is the older boolean form and still works;
 `VIEWSET_CLASS` takes precedence when both are set.
 
-4. (Optional) If you'd like to use the default OpenID Connect Viewset register the urls located in `oidc.urls`.
+1. (Optional) If you'd like to use the default OpenID Connect Viewset register the urls located in `oidc.urls`.
 
 ```python
 # urls.py file

--- a/README.md
+++ b/README.md
@@ -186,6 +186,216 @@ restores the value from cache and uses it as the post-auth redirect.
 With `USE_NONCES=False` the nonce is still emitted purely as the cache
 key — no IdP-side nonce verification is performed.
 
+### Keycloak Account REST proxy (`ACCOUNT_ENDPOINT`)
+
+The account-proxy actions (sessions, linked accounts, credentials) forward
+to Keycloak's Account REST API, and are read-and-revoke only — there is no
+profile-update endpoint. Being Keycloak-specific, they live in
+`KeycloakAccountMixin` rather than in the base viewset, and a deployment
+opts in by routing to a viewset that mixes them in:
+
+```python
+# Ready-made: the default viewset plus the proxy.
+OPENID_CONNECT_VIEWSET_CONFIG = {
+    "VIEWSET_CLASS": "oidc.keycloak.KeycloakOpenIDConnectViewset",
+}
+```
+
+```python
+# Or compose it with your own subclass.
+from oidc.keycloak import KeycloakAccountMixin
+from oidc.viewsets import UserModelOpenIDConnectViewset
+
+
+class MyOpenIDConnectViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    ...
+```
+
+Without the mixin these routes are not generated at all. Then point
+`ACCOUNT_ENDPOINT` at that realm's account root:
+
+```python
+OPENID_CONNECT_AUTH_SERVERS = {
+    "keycloak": {
+        ...,
+        "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/example/account",
+    }
+}
+```
+
+The setting is optional; with the mixin in place but `ACCOUNT_ENDPOINT`
+unset, the proxy actions return `503`. Calls are made with the signed-in user's own `access_token`, so
+they need the `manage-account` role — granted to every realm user by
+default.
+
+The proxy also requires a **token-producing flow**: the access/refresh
+pair it spends is only ever obtained by the authorization-code exchange
+at callback time. That means, for the auth server used with the proxy:
+
+* `RESPONSE_TYPE: "code"` — the repository default is `"id_token"`
+  (implicit flow), which returns an id_token only. With it, login works
+  but nothing is stashed, and every proxy action answers `401` even
+  though `ACCOUNT_ENDPOINT` is set — a symptom worth recognising.
+* `TOKEN_ENDPOINT` set — used for the code exchange and again for the
+  refresh-on-401 retry. Unset, it breaks the callback itself: the exchange
+  posts to `None` and the login ends on the `401` error page, so you never
+  reach the proxy. The `503` case is the refresh path only.
+
+A hybrid `RESPONSE_TYPE` such as `"code id_token"` does not work either —
+the callback short-circuits the code exchange whenever an `id_token` is
+already present, so no access token is ever obtained.
+
+These routes take identity from the OIDC tokens in `request.session`
+rather than `request.user`, and so run with DRF authentication
+disabled. All methods are instead gated by `IsCsrfSafeAccountRequest`:
+every request's `Origin` must be absent (same-origin) or in the same
+trusted-host set as `LOGIN_REDIRECT_ALLOWED_HOSTS` — this is what keeps
+the listings unreadable even from a deployment whose CORS reflects
+arbitrary origins — and state-changing methods must additionally carry a
+custom header. Neither check depends on the session cookie's `SameSite`
+attribute or on the deployment's CORS configuration.
+
+The header defaults to `X-Ona-Account-Request` and is configurable:
+
+```python
+OPENID_CONNECT_VIEWSET_CONFIG = {
+    ...,
+    "ACCOUNT_REQUEST_HEADER": "X-Acme-Account-Request",
+}
+```
+
+Any name works as a CSRF defence — what matters is that cross-site
+markup cannot set a custom header at all, not which name is used. The
+SPA must send whichever name is configured.
+
+#### Session tokens are scoped per auth server
+
+`OPENID_CONNECT_AUTH_SERVERS` is a keyed dict and every key gets its own
+routes, so the URL selects the provider while the Django session holds the
+tokens. They are therefore stored under provider-scoped session keys —
+`oidc_access_token:<auth_server>`, `oidc_refresh_token:<auth_server>` and
+`oidc_id_token:<auth_server>` — rather than one global name.
+
+This matters only in multi-provider deployments, where a single global key
+would be readable from *every* provider's route: a request to provider B
+would spend provider A's access token against B's account endpoint and,
+because B answers a foreign token with `401` (which the retry path reads as
+"expired"), go on to POST A's long-lived refresh token to B's token
+endpoint. Logout would likewise replay A's `id_token` to B as
+`id_token_hint`. Scoping makes those unrepresentable rather than merely
+checked.
+
+There is deliberately no fallback read of the old un-scoped keys — that
+would reinstate the cross-provider path. Sessions established before this
+change get one `401` and sign in again, the same fallback sessions
+predating the token stash already hit.
+
+`logout` clears all three of this provider's keys before redirecting to
+the end-session endpoint. That redirect may never be completed — closed
+tab, declined confirm screen, unreachable IdP — so it is the only point
+in the flow the server controls; leaving the pair behind would let a
+logged-out session keep calling the account proxy as the user. Other
+providers' tokens are untouched, since logout is per-provider.
+
+The tokens are also only written once the login is *accepted*. The IdP
+vouching for a user is not the platform accepting them — the callback can
+still refuse (`AUTO_CREATE_USER` off, required claims missing, validation
+failures) — so nothing touches the session until the success exit. A
+refused caller's session therefore gets a `401` from the proxy, and no
+credential is left at rest for a caller who, never having signed in, will
+never log out to clear it.
+
+One flow needs more than that: when the claims carry no usable username
+the callback answers with an entry form, and the browser re-POSTs only
+the `id_token` — so the access/refresh pair obtained by the first request
+is parked in `<name>:<auth_server>:pending` until the resubmit. Those
+slots are written on that path alone. The parked pair is tagged with the
+`id_token` it belongs to and handed back only on a match, because one
+session can be running two logins at once (two tabs): pairing one login's
+`id_token` with another's tokens would sign the browser in as one
+identity while the proxy acted on the other's Keycloak account. A
+mismatch is dropped, so login completes and the proxy answers `401` until
+the next full sign-in.
+
+Because that session now carries a refresh token, two Django-level
+choices stop being neutral:
+
+* **A server-side `SESSION_ENGINE` is required.** Signed-cookie sessions
+  are signed but not encrypted — the contents are client-readable and stay
+  replayable after logout, since there is no server-side record to delete.
+  Pairing that backend with a proxy-enabled viewset is a deploy check
+  (`oidc.E001`), so `manage.py check` fails rather than the first user who
+  tries to sign in; the viewset also refuses at request time as a backstop.
+  Viewsets that keep only the id_token (which the browser already holds)
+  are unaffected.
+* **The session id is rotated when the tokens are written.** Django's
+  `login()` would do this, but only runs under `USE_AUTH_BACKEND`, so the
+  proxy calls `cycle_key()` itself — otherwise a planted session id would
+  end up holding the victim's tokens.
+
+Outbound calls to the IdP carry a `(connect, read)` timeout, default
+`(5, 15)`, configurable per auth server:
+
+```python
+OPENID_CONNECT_AUTH_SERVERS = {
+    "keycloak": {
+        ...,
+        "REQUEST_TIMEOUT": (5, 15),
+    }
+}
+```
+
+`logout` also removes the pre-namespacing `oidc_id_token` /
+`oidc_access_token` / `oidc_refresh_token` keys. That is a write-side
+sweep only — it does not reinstate the fallback *read*, so it cannot
+bring back the cross-provider path. Without it, a token stashed before
+the rename would outlive every sign-out, since the session is flushed
+only under `USE_AUTH_BACKEND`.
+
+#### Deployment requirements for the origin checks
+
+The trusted-host set is `LOGIN_REDIRECT_ALLOWED_HOSTS` plus the request's
+own host, so both the `next` validation and the account-proxy `Origin`
+check inherit their strength from Django's `ALLOWED_HOSTS`:
+
+* **Scope `ALLOWED_HOSTS` to the hosts you serve.** The request host is
+  read via `request.get_host()`, which Django rejects with a `400`
+  unless it matches `ALLOWED_HOSTS`. That validation is what keeps an
+  attacker-supplied `Host` out of the trusted set. With
+  `ALLOWED_HOSTS = ["*"]` there is no validation left, the header is
+  echoed back verbatim, and both checks degrade to comparing one
+  request header against another.
+
+* **With `USE_X_FORWARDED_HOST = True`, the proxy must strip any
+  client-supplied `X-Forwarded-Host`.** Django prefers that header over
+  `Host`, and unlike `Host` a page can set it on a `fetch`. A proxy that
+  forwards it lets a caller nominate its own origin as trusted.
+
+### Routing to your own viewset (`VIEWSET_CLASS`)
+
+Deployments that subclass the viewset — to reject certain account types,
+adjust cookie handling, and so on — can keep using `include("oidc.urls")`
+by naming the subclass:
+
+```python
+OPENID_CONNECT_VIEWSET_CONFIG = {
+    ...,
+    "VIEWSET_CLASS": "myapp.oidc_viewsets.MyOpenIDConnectViewset",
+}
+```
+
+Every route then goes to that class, including the account-proxy routes
+and their CSRF configuration. Without this the only way to change the
+viewset is to copy `oidc/urls.py` into your project, which means
+mirroring every future route and every `as_view()` kwarg by hand.
+
+An unimportable path raises rather than falling back to the built-in
+viewset — a silent fallback would drop whatever access rules the
+subclass enforces.
+
+`USE_RAPIDPRO_VIEWSET` is the older boolean form and still works;
+`VIEWSET_CLASS` takes precedence when both are set.
+
 4. (Optional) If you'd like to use the default OpenID Connect Viewset register the urls located in `oidc.urls`.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ OPENID_CONNECT_AUTH_SERVERS = {
 ```
 
 The setting is optional; with the mixin in place but `ACCOUNT_ENDPOINT`
-unset, the proxy actions return `503`. Calls are made with the signed-in user's own `access_token`, so
+unset, the proxy actions return `503` to a caller who has a session and
+`401` to one who does not. Calls are made with the signed-in user's own `access_token`, so
 they need the `manage-account` role which is granted to every realm user by
 default.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A pluggable django application that implements OpenID Connect client functionali
 pip install -e git+https://github.com/onaio/ona-oidc.git#egg=ona-oidc
 ```
 
-1. Add `oidc` to the list of `INSTALLED_APPS`
+2. Add `oidc` to the list of `INSTALLED_APPS`
 
 ```python
 ...
@@ -25,12 +25,12 @@ INSTALLED_APPS = [
 
 ```
 
-The username-entry form and the error page extend `base.html`, and the
-package ships a plain one so a fresh install renders. To use your own,
-put it on `TEMPLATES["DIRS"]` or in an app listed before `oidc`; it only
-needs `title` and `content` blocks.
+   Note: the username-entry form and the error page extend `base.html`.
+   The package ships a plain one so a fresh install renders; a project's
+   own wins from `TEMPLATES["DIRS"]` or from an app listed before `oidc`,
+   and only needs `title` and `content` blocks.
 
-1. Set `OPENID_CONNECT_VIEWSET_CONFIG` and `OPENID_CONNECT_AUTH_SERVERS` settings
+3. Set `OPENID_CONNECT_VIEWSET_CONFIG` and `OPENID_CONNECT_AUTH_SERVERS` settings
 
 ```python
 ...
@@ -356,7 +356,7 @@ subclass enforces.
 `USE_RAPIDPRO_VIEWSET` is the older boolean form and still works;
 `VIEWSET_CLASS` takes precedence when both are set.
 
-1. (Optional) If you'd like to use the default OpenID Connect Viewset register the urls located in `oidc.urls`.
+4. (Optional) If you'd like to use the default OpenID Connect Viewset register the urls located in `oidc.urls`.
 
 ```python
 # urls.py file

--- a/oidc/apps.py
+++ b/oidc/apps.py
@@ -20,6 +20,10 @@ class oidcConfig(AppConfig):
         # Imported here rather than at module scope: the check pulls in the
         # viewsets, which read settings, and that must not happen while the
         # app registry is still populating.
-        from oidc.checks import check_session_backend_can_hold_tokens
+        from oidc.checks import (
+            check_actions_survive_subclassing,
+            check_session_backend_can_hold_tokens,
+        )
 
         register(check_session_backend_can_hold_tokens, "security")
+        register(check_actions_survive_subclassing)

--- a/oidc/apps.py
+++ b/oidc/apps.py
@@ -3,6 +3,7 @@ Application Module for oidc app
 """
 
 from django.apps import AppConfig
+from django.core.checks import register
 from django.utils.translation import gettext_lazy as _
 
 
@@ -14,3 +15,11 @@ class oidcConfig(AppConfig):
     name = "oidc"
     app_label = "oidc"
     verbose_name = _("OpenID Connect")
+
+    def ready(self):
+        # Imported here rather than at module scope: the check pulls in the
+        # viewsets, which read settings, and that must not happen while the
+        # app registry is still populating.
+        from oidc.checks import check_session_backend_can_hold_tokens
+
+        register(check_session_backend_can_hold_tokens, "security")

--- a/oidc/checks.py
+++ b/oidc/checks.py
@@ -55,3 +55,42 @@ def check_session_backend_can_hold_tokens(app_configs, **kwargs):
             id="oidc.E001",
         )
     ]
+
+
+def check_actions_survive_subclassing(app_configs, **kwargs):
+    """Catch a subclass that overrode an ``@action`` without re-declaring it.
+
+    The router builds routes from the ``@action`` metadata attached to the
+    function. A plain override replaces the function and drops that
+    metadata, so the route is never generated -- the endpoint 404s with
+    nothing to indicate why. Silent, and only reachable through
+    ``VIEWSET_CLASS``, so it belongs at deploy time.
+    """
+    from oidc.urls import get_viewset_class
+
+    try:
+        viewset_class = get_viewset_class()
+    except Exception:  # pragma: no cover - a broken VIEWSET_CLASS is its own error
+        return []
+
+    routed = {action.__name__ for action in viewset_class.get_extra_actions()}
+    errors = []
+    for klass in viewset_class.__mro__[1:]:
+        for name, inherited in vars(klass).items():
+            if not hasattr(inherited, "mapping") or name in routed:
+                continue
+            errors.append(
+                Error(
+                    f"{viewset_class.__name__}.{name}() overrides an @action "
+                    f"declared on {klass.__name__} without re-declaring it, so "
+                    f"no route is generated for it.",
+                    hint=(
+                        f"Re-apply the decorator on the override, mirroring "
+                        f"{klass.__name__}.{name}: @action(methods=..., "
+                        f"detail=False, url_path=..., url_name=...)."
+                    ),
+                    id="oidc.E002",
+                )
+            )
+            routed.add(name)
+    return errors

--- a/oidc/checks.py
+++ b/oidc/checks.py
@@ -69,10 +69,37 @@ _GUARDED_VIEW_KWARGS = (
 )
 
 
+def _required_classes(entry) -> set:
+    """Everything an entry demands unconditionally.
+
+    ``A & B`` does not keep both classes in the list -- DRF builds a single
+    ``OperandHolder`` -- so a subclass that *tightened* a route by composing
+    would look, to a plain membership test, exactly like one that dropped
+    the gate. Only ``AND`` is flattened: ``A | B`` is a weakening, and has
+    to be reported.
+    """
+    operator = getattr(entry, "operator_class", None)
+    if operator is not None and operator.__name__ == "AND":
+        return _required_classes(entry.op1_class) | _required_classes(entry.op2_class)
+    return {entry}
+
+
 def _kwarg_survives(inherited, current, key: str) -> bool:
-    return set(getattr(inherited, "kwargs", {}).get(key) or ()) <= set(
-        getattr(current, "kwargs", {}).get(key) or ()
-    )
+    """Whether the override still demands everything the parent declared.
+
+    Presence is checked before content: ``authentication_classes=[]`` is
+    declared empty on purpose, and an empty set is a subset of anything --
+    including of an override that dropped the kwarg entirely and inherited
+    DRF's session and basic auth, CSRF enforcement and all.
+    """
+    declared = getattr(inherited, "kwargs", {})
+    if key not in declared:
+        return True
+    kept = getattr(current, "kwargs", {})
+    if key not in kept:
+        return False
+    required = set().union(*(_required_classes(e) for e in kept[key] or ())) or set()
+    return set(declared[key] or ()) <= required
 
 
 def _hint_kwargs(inherited) -> str:

--- a/oidc/checks.py
+++ b/oidc/checks.py
@@ -1,0 +1,57 @@
+"""
+Deployment checks for the oidc app.
+
+Registered from ``oidcConfig.ready``, so they run on ``manage.py check``,
+``migrate``, ``runserver`` and any other management command -- i.e. at
+deploy time rather than on the first user who tries to sign in.
+"""
+
+from django.conf import settings
+from django.core.checks import Error
+
+_COOKIE_BACKEND = "django.contrib.sessions.backends.signed_cookies"
+
+
+def check_session_backend_can_hold_tokens(app_configs, **kwargs):
+    """Refuse to keep OIDC tokens in a client-readable session.
+
+    Signed-cookie sessions are signed but not encrypted: the contents ride
+    in a cookie the browser can read, and stay replayable after logout
+    because there is no server-side record to delete. That is tolerable for
+    the id_token alone -- the browser already holds it -- but not for the
+    access and refresh tokens a proxy-enabled viewset stores.
+
+    ``BaseOpenIDConnectViewset.__init__`` also refuses this, but a viewset
+    is only instantiated per request, so on its own that surfaces as a 500
+    for the first user to sign in. This runs at deploy time instead.
+    """
+    if getattr(settings, "SESSION_ENGINE", "") != _COOKIE_BACKEND:
+        return []
+
+    # Imported lazily: this module is imported from ``ready()``, and
+    # ``oidc.urls`` pulls in the viewsets, which read settings at import.
+    from oidc.urls import get_viewset_class
+
+    try:
+        viewset_class = get_viewset_class()
+    except Exception:  # pragma: no cover - a broken VIEWSET_CLASS is its own error
+        return []
+
+    if not getattr(viewset_class, "stash_oidc_tokens", False):
+        return []
+
+    return [
+        Error(
+            "SESSION_ENGINE is the signed_cookies backend, but "
+            f"{viewset_class.__name__} stores OIDC access and refresh tokens "
+            "in request.session.",
+            hint=(
+                "Cookie-based sessions are signed but not encrypted, so the "
+                "tokens would be readable by the client and replayable after "
+                "logout. Use a server-side SESSION_ENGINE (db, cache, "
+                "cached_db or file), or route to a viewset that does not mix "
+                "in KeycloakAccountMixin."
+            ),
+            id="oidc.E001",
+        )
+    ]

--- a/oidc/checks.py
+++ b/oidc/checks.py
@@ -57,18 +57,56 @@ def check_session_backend_can_hold_tokens(app_configs, **kwargs):
     ]
 
 
+#: View kwargs an override has to carry forward. Dropping ``permission_classes``
+#: falls back to the viewset default -- ``AllowAny`` -- which on an
+#: account-proxy route silently removes the CSRF/Origin gate, and the route
+#: still looks identical by path, name and verb. Compared as subsets so a
+#: subclass may add to them.
+_GUARDED_VIEW_KWARGS = (
+    "permission_classes",
+    "authentication_classes",
+    "renderer_classes",
+)
+
+
+def _kwarg_survives(inherited, current, key: str) -> bool:
+    return set(getattr(inherited, "kwargs", {}).get(key) or ()) <= set(
+        getattr(current, "kwargs", {}).get(key) or ()
+    )
+
+
+def _hint_kwargs(inherited) -> str:
+    """The guarded view kwargs, spelled out so the hint can be copied."""
+    declared = [
+        f"{key}={[c.__name__ for c in getattr(inherited, 'kwargs', {})[key]]}"
+        for key in _GUARDED_VIEW_KWARGS
+        if key in getattr(inherited, "kwargs", {})
+    ]
+    return ", ".join(declared) if declared else "its view kwargs"
+
+
 def _routes_match(inherited, current) -> bool:
     """Whether an override still produces the route its parent declared.
 
     Name equality is not enough: a re-declared decorator with a different
-    ``url_path`` moves the endpoint, a different ``url_name`` breaks
-    ``reverse()``, and a fresh ``MethodMapper`` silently drops any
-    ``@<action>.mapping.<verb>`` companion the parent had.
+    ``url_path`` moves the endpoint, ``detail=True`` moves it again by
+    adding a ``pk`` segment, a different ``url_name`` breaks ``reverse()``,
+    a fresh ``MethodMapper`` silently drops any ``@<action>.mapping.<verb>``
+    companion the parent had, and omitted view kwargs quietly widen who may
+    call it.
+
+    The mapping is compared by verb rather than by (verb, handler name): the
+    route carries the verbs, so renaming the method a companion points at is
+    a rename, not a lost route.
     """
     return (
         getattr(inherited, "url_path", None) == getattr(current, "url_path", None)
         and getattr(inherited, "url_name", None) == getattr(current, "url_name", None)
-        and inherited.mapping.items() <= current.mapping.items()
+        and getattr(inherited, "detail", None) == getattr(current, "detail", None)
+        and inherited.mapping.keys() <= current.mapping.keys()
+        and all(
+            _kwarg_survives(inherited, current, key) for key in _GUARDED_VIEW_KWARGS
+        )
     )
 
 
@@ -106,10 +144,12 @@ def check_actions_survive_subclassing(app_configs, **kwargs):
                         f"Re-apply the decorator on the override, matching "
                         f"{klass.__name__}.{name} exactly: url_path="
                         f"{getattr(inherited, 'url_path', None)!r}, url_name="
-                        f"{getattr(inherited, 'url_name', None)!r}, and at "
-                        f"least the methods {sorted(inherited.mapping)}. Any "
-                        f"@{name}.mapping.<verb> companions must be "
-                        f"re-declared too -- a fresh decorator replaces them."
+                        f"{getattr(inherited, 'url_name', None)!r}, detail="
+                        f"{getattr(inherited, 'detail', None)!r}, at least the "
+                        f"methods {sorted(inherited.mapping)}, and "
+                        f"{_hint_kwargs(inherited)}. Any @{name}.mapping.<verb> "
+                        f"companions must be re-declared too -- a fresh "
+                        f"decorator replaces them."
                     ),
                     id="oidc.E002",
                 )

--- a/oidc/checks.py
+++ b/oidc/checks.py
@@ -57,6 +57,21 @@ def check_session_backend_can_hold_tokens(app_configs, **kwargs):
     ]
 
 
+def _routes_match(inherited, current) -> bool:
+    """Whether an override still produces the route its parent declared.
+
+    Name equality is not enough: a re-declared decorator with a different
+    ``url_path`` moves the endpoint, a different ``url_name`` breaks
+    ``reverse()``, and a fresh ``MethodMapper`` silently drops any
+    ``@<action>.mapping.<verb>`` companion the parent had.
+    """
+    return (
+        getattr(inherited, "url_path", None) == getattr(current, "url_path", None)
+        and getattr(inherited, "url_name", None) == getattr(current, "url_name", None)
+        and inherited.mapping.items() <= current.mapping.items()
+    )
+
+
 def check_actions_survive_subclassing(app_configs, **kwargs):
     """Catch a subclass that overrode an ``@action`` without re-declaring it.
 
@@ -73,24 +88,31 @@ def check_actions_survive_subclassing(app_configs, **kwargs):
     except Exception:  # pragma: no cover - a broken VIEWSET_CLASS is its own error
         return []
 
-    routed = {action.__name__ for action in viewset_class.get_extra_actions()}
+    routed = {action.__name__: action for action in viewset_class.get_extra_actions()}
     errors = []
     for klass in viewset_class.__mro__[1:]:
         for name, inherited in vars(klass).items():
-            if not hasattr(inherited, "mapping") or name in routed:
+            if not hasattr(inherited, "mapping"):
+                continue
+            current = routed.get(name)
+            if current is not None and _routes_match(inherited, current):
                 continue
             errors.append(
                 Error(
-                    f"{viewset_class.__name__}.{name}() overrides an @action "
-                    f"declared on {klass.__name__} without re-declaring it, so "
-                    f"no route is generated for it.",
+                    f"{viewset_class.__name__}.{name}() overrides the @action "
+                    f"declared on {klass.__name__} without preserving its "
+                    f"route.",
                     hint=(
-                        f"Re-apply the decorator on the override, mirroring "
-                        f"{klass.__name__}.{name}: @action(methods=..., "
-                        f"detail=False, url_path=..., url_name=...)."
+                        f"Re-apply the decorator on the override, matching "
+                        f"{klass.__name__}.{name} exactly: url_path="
+                        f"{getattr(inherited, 'url_path', None)!r}, url_name="
+                        f"{getattr(inherited, 'url_name', None)!r}, and at "
+                        f"least the methods {sorted(inherited.mapping)}. Any "
+                        f"@{name}.mapping.<verb> companions must be "
+                        f"re-declared too -- a fresh decorator replaces them."
                     ),
                     id="oidc.E002",
                 )
             )
-            routed.add(name)
+            routed[name] = inherited  # don't report the same name twice
     return errors

--- a/oidc/client.py
+++ b/oidc/client.py
@@ -542,3 +542,45 @@ class OpenIDClient:
                 # surface as ``None``.
                 body = None
         return response.status_code, body
+
+    def request_keycloak_account(
+        self,
+        access_token: str,
+        method: str,
+        path_suffix: str,
+        json_body: Optional[Mapping[str, Any]] = None,
+    ) -> tuple[int, Optional[dict]]:
+        """
+        Issue a generic ``method`` request to ``account_endpoint + path_suffix``
+        on behalf of ``access_token``. Returns ``(status_code, body|None)``.
+
+        ``update_account_profile`` is the POST /account special-case kept
+        for backwards compatibility; new callers should use this helper.
+        """
+        if not self.account_endpoint:
+            raise ValueError(
+                f"ACCOUNT_ENDPOINT is not configured for auth_server "
+                f"{self.auth_server!r}."
+            )
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+        }
+        kwargs: dict = {"headers": headers}
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+            kwargs["json"] = dict(json_body)
+        url = f"{self.account_endpoint}{path_suffix}"
+        try:
+            response = requests.request(method, url, **kwargs)
+        except requests.RequestException as exc:
+            logger.exception(exc)
+            raise
+
+        body: Optional[dict] = None
+        if response.content:
+            try:
+                body = response.json()
+            except ValueError:
+                body = None
+        return response.status_code, body

--- a/oidc/client.py
+++ b/oidc/client.py
@@ -118,6 +118,17 @@ class EndpointNotConfigured(ValueError):
     """
 
 
+class UpstreamShapeError(Exception):
+    """A 2xx from the account endpoint whose body is not what it claims.
+
+    Reported to the caller as a bad gateway rather than forwarded. An empty
+    body is normal (a revoke answers 204); a body that will not parse means
+    something other than Keycloak answered -- an ingress maintenance page, a
+    WAF block, a misrouted vhost -- and forwarding it as success turns
+    "could not reach your sessions" into "you have no other sessions".
+    """
+
+
 def _coerce_request_timeout(value, auth_server: str):
     """Normalise ``REQUEST_TIMEOUT`` to what ``requests`` accepts.
 
@@ -588,7 +599,15 @@ class OpenIDClient:
         url = f"{self.account_endpoint}{path_suffix}"
         try:
             response = requests.request(
-                method, url, headers=headers, timeout=self.request_timeout
+                method,
+                url,
+                headers=headers,
+                timeout=self.request_timeout,
+                # A redirect here is never the account API answering. Following
+                # one silently lands on whatever is at the other end -- often a
+                # login or maintenance page that returns 200 with HTML, which
+                # then reads as a successful, empty result.
+                allow_redirects=False,
             )
         except requests.RequestException as exc:
             logger.exception(exc)
@@ -598,6 +617,13 @@ class OpenIDClient:
         if response.content:
             try:
                 body = response.json()
-            except ValueError:
+            except ValueError as exc:
+                if 200 <= response.status_code < 300:
+                    raise UpstreamShapeError(
+                        f"{method} {path_suffix} answered "
+                        f"{response.status_code} with a body that is not JSON."
+                    ) from exc
+                # On an error status the body is only ever echoed back as
+                # context, so an unparseable one costs nothing.
                 body = None
         return response.status_code, body

--- a/oidc/client.py
+++ b/oidc/client.py
@@ -186,16 +186,8 @@ class OpenIDClient:
                 "NONCE_CACHE_TIMEOUT", default_config["NONCE_CACHE_TIMEOUT"]
             )
         )
-        # ``requests`` waits forever by default, so an IdP that accepts a
-        # connection and then stalls pins the worker handling it — no error,
-        # no recovery. Every account-proxy call and every callback goes
-        # through this client, so a handful of stalled requests is enough to
-        # exhaust the pool. Tuple form: (connect, read).
-        # Coerced, like every other setting here: ``requests`` accepts only
-        # a number or a 2-tuple, so a string from an env var or a list from
-        # JSON/YAML settings -- the natural serialised form of the documented
-        # value -- would raise on every login and every proxy call, from deep
-        # inside urllib3 and naming neither this setting nor ona-oidc.
+        # ``requests`` waits forever without this, so a stalled IdP pins the
+        # worker. Coerced because it accepts only a number or a 2-tuple.
         self.request_timeout = _coerce_request_timeout(
             config[auth_server].get(
                 "REQUEST_TIMEOUT", default_config["REQUEST_TIMEOUT"]

--- a/oidc/client.py
+++ b/oidc/client.py
@@ -558,6 +558,10 @@ class OpenIDClient:
                 data=data,
                 headers=headers,
                 timeout=self.request_timeout,
+                # As on the account call: a redirect here is not the token
+                # endpoint answering, and following it lands on a page that
+                # returns 200 with something that is not a token response.
+                allow_redirects=False,
             )
             response.raise_for_status()
         except requests.HTTPError as exc:
@@ -568,11 +572,17 @@ class OpenIDClient:
             raise TokenVerificationFailed(
                 f"Failed to refresh access token: {exc}"
             ) from exc
-        # Transport failures (DNS, timeout) are left to propagate, as is a
-        # non-JSON body. Reporting an unreachable IdP as "session expired" would
-        # send the user through a re-login that cannot fix it; the proxy maps
-        # RequestException to 502 instead.
-        return response.json()
+        # Transport failures (DNS, timeout) are left to propagate: reporting an
+        # unreachable IdP as "session expired" would send the user through a
+        # re-login that cannot fix it, and the proxy maps RequestException to
+        # 502 instead.
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise UpstreamShapeError(
+                f"token endpoint answered {response.status_code} with a body "
+                f"that is not JSON."
+            ) from exc
 
     def request_keycloak_account(
         self,

--- a/oidc/client.py
+++ b/oidc/client.py
@@ -12,6 +12,7 @@ from urllib.parse import quote, urlencode
 
 from django.conf import settings
 from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseRedirect
 
 import jwt
@@ -117,6 +118,33 @@ class EndpointNotConfigured(ValueError):
     """
 
 
+def _coerce_request_timeout(value, auth_server: str):
+    """Normalise ``REQUEST_TIMEOUT`` to what ``requests`` accepts.
+
+    A 2-item list/tuple becomes ``(connect, read)``; anything else numeric
+    becomes a single float. ``None`` is rejected rather than honoured: it is
+    ``requests``' "wait forever", which is the failure this setting exists
+    to prevent, and accepting it silently would make an unbounded wait look
+    configured on purpose.
+    """
+    if value is None:
+        raise ImproperlyConfigured(
+            f"OPENID_CONNECT_AUTH_SERVERS[{auth_server!r}]['REQUEST_TIMEOUT'] "
+            f"is None, which disables the timeout entirely. Give a number of "
+            f"seconds, or a (connect, read) pair."
+        )
+    if isinstance(value, (list, tuple)):
+        if len(value) != 2:
+            raise ImproperlyConfigured(
+                f"OPENID_CONNECT_AUTH_SERVERS[{auth_server!r}]"
+                f"['REQUEST_TIMEOUT'] must be a (connect, read) pair, got "
+                f"{len(value)} item(s): {value!r}."
+            )
+        connect, read = value
+        return (float(connect), float(read))
+    return float(value)
+
+
 class OpenIDClient:
     """
     OpenID connect client class
@@ -163,8 +191,16 @@ class OpenIDClient:
         # no recovery. Every account-proxy call and every callback goes
         # through this client, so a handful of stalled requests is enough to
         # exhaust the pool. Tuple form: (connect, read).
-        self.request_timeout = config[auth_server].get(
-            "REQUEST_TIMEOUT", default_config["REQUEST_TIMEOUT"]
+        # Coerced, like every other setting here: ``requests`` accepts only
+        # a number or a 2-tuple, so a string from an env var or a list from
+        # JSON/YAML settings -- the natural serialised form of the documented
+        # value -- would raise on every login and every proxy call, from deep
+        # inside urllib3 and naming neither this setting nor ona-oidc.
+        self.request_timeout = _coerce_request_timeout(
+            config[auth_server].get(
+                "REQUEST_TIMEOUT", default_config["REQUEST_TIMEOUT"]
+            ),
+            auth_server,
         )
         self.use_pkce = str_to_bool(
             config[auth_server].get("USE_PKCE", default_config["USE_PKCE"])

--- a/oidc/client.py
+++ b/oidc/client.py
@@ -106,6 +106,17 @@ class TokenVerificationFailed(Exception):
     pass
 
 
+class EndpointNotConfigured(ValueError):
+    """A required ``*_ENDPOINT`` is missing for this auth server.
+
+    Distinct from a transport failure so callers can tell "we never
+    configured this" from "the IdP is down" -- ``requests`` raises
+    ``JSONDecodeError``, which is *both* a ``ValueError`` and a
+    ``RequestException``, so catching bare ``ValueError`` would sweep up a
+    malformed IdP response and report it as our own misconfiguration.
+    """
+
+
 class OpenIDClient:
     """
     OpenID connect client class
@@ -126,6 +137,7 @@ class OpenIDClient:
         self.scope = config[auth_server].get("SCOPE") or default_config["SCOPE"]
         self.token_endpoint = config[auth_server].get("TOKEN_ENDPOINT")
         self.end_session_endpoint = config[auth_server].get("END_SESSION_ENDPOINT")
+        self.account_endpoint = config[auth_server].get("ACCOUNT_ENDPOINT")
         self.redirect_uri = config[auth_server].get("REDIRECT_URI")
         self.response_type = config[auth_server].get(
             "RESPONSE_TYPE", default_config["RESPONSE_TYPE"]
@@ -145,6 +157,14 @@ class OpenIDClient:
             config[auth_server].get(
                 "NONCE_CACHE_TIMEOUT", default_config["NONCE_CACHE_TIMEOUT"]
             )
+        )
+        # ``requests`` waits forever by default, so an IdP that accepts a
+        # connection and then stalls pins the worker handling it — no error,
+        # no recovery. Every account-proxy call and every callback goes
+        # through this client, so a handful of stalled requests is enough to
+        # exhaust the pool. Tuple form: (connect, read).
+        self.request_timeout = config[auth_server].get(
+            "REQUEST_TIMEOUT", default_config["REQUEST_TIMEOUT"]
         )
         self.use_pkce = str_to_bool(
             config[auth_server].get("USE_PKCE", default_config["USE_PKCE"])
@@ -172,7 +192,7 @@ class OpenIDClient:
         Retrieves a JSON Web Key Set that can be used to verify a
         JSON web token issued by an authentication server.
         """
-        response = requests.get(self.jwks_endpoint)
+        response = requests.get(self.jwks_endpoint, timeout=self.request_timeout)
         if response.status_code == 200:
             jwks = response.json()
             for jwk in jwks.get("keys"):
@@ -185,7 +205,9 @@ class OpenIDClient:
         Given an access_token, retrieve user profile claims
         """
         response = requests.get(
-            self.user_info_endpoint, headers={"Authorization": f"Bearer {access_token}"}
+            self.user_info_endpoint,
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=self.request_timeout,
         )
         return response.json()
 
@@ -348,6 +370,7 @@ class OpenIDClient:
                 data=data if self.request_mode == "form_post" else None,
                 params=data if self.request_mode == "query" else None,
                 headers=headers,
+                timeout=self.request_timeout,
             )
             response.raise_for_status()
 
@@ -466,3 +489,87 @@ class OpenIDClient:
         separator = "&" if "?" in url else "?"
         query = urlencode(filtered, quote_via=quote, safe=_AUTHORIZE_URL_SAFE_CHARS)
         return HttpResponseRedirect(f"{url}{separator}{query}")
+
+    def refresh_access_token(self, refresh_token: str) -> dict:
+        """
+        Exchange a refresh_token for a fresh token pair at the
+        configured ``TOKEN_ENDPOINT``. Returns the parsed token
+        response (``access_token``, ``refresh_token``, ``expires_in``,
+        usually a new ``id_token`` too).
+
+        :raises EndpointNotConfigured: ``TOKEN_ENDPOINT`` is unset.
+        :raises TokenVerificationFailed: the IdP answered and refused.
+        :raises requests.RequestException: the IdP could not be reached.
+        """
+        if not self.token_endpoint:
+            raise EndpointNotConfigured(
+                f"TOKEN_ENDPOINT is not configured for auth_server "
+                f"{self.auth_server!r}."
+            )
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        try:
+            response = requests.post(
+                self.token_endpoint,
+                data=data,
+                headers=headers,
+                timeout=self.request_timeout,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            # The IdP answered and refused: the refresh token is spent,
+            # revoked, or issued to another client. That is a genuinely
+            # dead session, so the caller turns this into a 401.
+            logger.exception(exc)
+            raise TokenVerificationFailed(
+                f"Failed to refresh access token: {exc}"
+            ) from exc
+        # Transport failures (DNS, timeout) are left to propagate, as is a
+        # non-JSON body. Reporting an unreachable IdP as "session expired" would
+        # send the user through a re-login that cannot fix it; the proxy maps
+        # RequestException to 502 instead.
+        return response.json()
+
+    def request_keycloak_account(
+        self,
+        access_token: str,
+        method: str,
+        path_suffix: str,
+    ) -> tuple[int, Optional[dict]]:
+        """
+        Issue a generic ``method`` request to ``account_endpoint + path_suffix``
+        on behalf of ``access_token``. Returns ``(status_code, body|None)``.
+
+        This is the single entry point for every Account REST proxy call
+        (sessions, linked-accounts, credentials).
+        """
+        if not self.account_endpoint:
+            raise EndpointNotConfigured(
+                f"ACCOUNT_ENDPOINT is not configured for auth_server "
+                f"{self.auth_server!r}."
+            )
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+        }
+        url = f"{self.account_endpoint}{path_suffix}"
+        try:
+            response = requests.request(
+                method, url, headers=headers, timeout=self.request_timeout
+            )
+        except requests.RequestException as exc:
+            logger.exception(exc)
+            raise
+
+        body: Optional[dict] = None
+        if response.content:
+            try:
+                body = response.json()
+            except ValueError:
+                body = None
+        return response.status_code, body

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -254,14 +254,17 @@ class KeycloakAccountMixin:
                 {"error": _("Unknown auth server.")},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        # Before the configuration check: whether this deployment has an
+        # ACCOUNT_ENDPOINT is not something to tell a caller who has not
+        # shown a session.
+        session = _authenticated_session(request, client.auth_server)
+        if session is None:
+            return Response(NO_ACTIVE_SESSION, status=status.HTTP_401_UNAUTHORIZED)
         if not client.account_endpoint:
             return Response(
                 {"error": "Account endpoint not configured."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
-        session = _authenticated_session(request, client.auth_server)
-        if session is None:
-            return Response(NO_ACTIVE_SESSION, status=status.HTTP_401_UNAUTHORIZED)
         try:
             status_code, body = self._keycloak_account_request(
                 client, session, method, path_suffix

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -252,7 +252,19 @@ class KeycloakAccountMixin:
                 status=status.HTTP_502_BAD_GATEWAY,
             )
         if status.is_success(status_code):
-            payload = transform(body) if transform else body
+            try:
+                payload = transform(body) if transform else body
+            except (AttributeError, TypeError, KeyError) as exc:
+                # A 2xx whose body isn't the shape we normalise -- a gateway
+                # answering 200 with an error object, or an upstream shape
+                # change. Narrow on purpose: a defect in our own transform
+                # should still surface as a 500 with a traceback rather than
+                # be reported as the IdP misbehaving.
+                logger.exception(exc)
+                return Response(
+                    {"error": "Unexpected response from the identity provider."},
+                    status=status.HTTP_502_BAD_GATEWAY,
+                )
             return Response(payload, status=status_code)
         return Response(
             {"error": "Identity provider rejected the request.", "upstream": body},

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -27,7 +27,12 @@ from rest_framework.decorators import action
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
-from oidc.client import EndpointNotConfigured, OpenIDClient, TokenVerificationFailed
+from oidc.client import (
+    EndpointNotConfigured,
+    OpenIDClient,
+    TokenVerificationFailed,
+    UpstreamShapeError,
+)
 from oidc.permissions import IsCsrfSafeAccountRequest
 from oidc.utils import (
     ACCESS_TOKEN_SESSION_KEY,
@@ -213,6 +218,15 @@ class KeycloakAccountMixin:
             return status.HTTP_401_UNAUTHORIZED, body
         return client.request_keycloak_account(new_access, method, path_suffix)
 
+    @staticmethod
+    def _bad_gateway(exc: Exception, method: str, path_suffix: str) -> Response:
+        """The IdP answered, but not with anything we can use."""
+        logger.exception("account proxy %s %s: %s", method, path_suffix, exc)
+        return Response(
+            {"error": "Unexpected response from the identity provider."},
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
+
     def _proxy_or_error(
         self,
         request: HttpRequest,
@@ -220,11 +234,16 @@ class KeycloakAccountMixin:
         method: str,
         path_suffix: str,
         transform: Optional[Callable[[Any], Any]] = None,
+        expect: Optional[type] = None,
     ) -> HttpResponse:
         """
         Shared wrapper for the proxy actions. ``transform`` runs on the
         parsed body so per-endpoint normalisation stays close to the
         action that needs it.
+
+        ``expect`` is the body type a 2xx must carry, for the actions that
+        forward it verbatim. Without it a gateway answering ``200 {"error":
+        ...}`` reaches the SPA as a successful, unreadable result.
         """
         client = self._get_client(auth_server=auth_server)
         if client is None:
@@ -269,20 +288,25 @@ class KeycloakAccountMixin:
                 {"error": "Could not reach the identity provider."},
                 status=status.HTTP_502_BAD_GATEWAY,
             )
+        except UpstreamShapeError as exc:
+            return self._bad_gateway(exc, method, path_suffix)
         if status.is_success(status_code):
+            if expect is not None and body is not None and not isinstance(body, expect):
+                return self._bad_gateway(
+                    UpstreamShapeError(f"expected {expect.__name__}, got {type(body)}"),
+                    method,
+                    path_suffix,
+                )
             try:
                 payload = transform(body) if transform else body
             except (AttributeError, TypeError, KeyError) as exc:
-                # A 2xx whose body isn't the shape we normalise -- a gateway
-                # answering 200 with an error object, or an upstream shape
-                # change. Narrow on purpose: a defect in our own transform
-                # should still surface as a 500 with a traceback rather than
-                # be reported as the IdP misbehaving.
-                logger.exception(exc)
-                return Response(
-                    {"error": "Unexpected response from the identity provider."},
-                    status=status.HTTP_502_BAD_GATEWAY,
-                )
+                # A 2xx that parsed but is not the shape we normalise -- a
+                # nested field renamed, ``sessions`` arriving as a string.
+                # Nothing here can tell that from a defect in the transform
+                # itself, so both are reported as a bad gateway and the
+                # traceback goes to the log. Keep transforms small enough
+                # that the distinction rarely matters.
+                return self._bad_gateway(exc, method, path_suffix)
             return Response(payload, status=status_code)
         return Response(
             {"error": "Identity provider rejected the request.", "upstream": body},
@@ -388,6 +412,7 @@ class KeycloakAccountMixin:
             kwargs.get("auth_server"),
             "GET",
             "/linked-accounts",
+            expect=list,
         )
 
     @action(
@@ -441,6 +466,7 @@ class KeycloakAccountMixin:
             kwargs.get("auth_server"),
             "GET",
             f"/linked-accounts/{provider}",
+            expect=dict,
         )
 
     @action(
@@ -465,6 +491,7 @@ class KeycloakAccountMixin:
             kwargs.get("auth_server"),
             "GET",
             "/credentials",
+            expect=list,
         )
 
     @staticmethod

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -39,33 +39,15 @@ from oidc.viewsets import UserModelOpenIDConnectViewset
 logger = logging.getLogger(__name__)
 
 
-#: Keycloak identity-provider aliases routinely look like hostnames
-#: (``idp.acme.com`` — Keycloak itself builds ``brokerUserId`` as
-#: ``alias + "." + federatedUserId``) and are case-sensitive, so both the dot
-#: and uppercase belong in the charset. A lowercase-only allowlist without the
-#: dot silently 400s a correctly configured realm's IdP.
-#:
-#: ``/`` deliberately stays out. These values are interpolated into the
-#: upstream URL and ``requests`` resolves dot segments before sending, so a
-#: separator would let an alias form path segments of its own. With no
-#: separator available the only traversal left is an alias that is *entirely*
-#: a dot segment, rejected below.
-#:
-#: Aliases outside this charset (spaces, unicode) are refused rather than
-#: percent-encoded: they are vanishingly rare, and every character here is
-#: URL-unreserved, so encoding would be a no-op that only obscured the rule.
-#:
-#: Matched with ``fullmatch`` and deliberately unanchored: with ``^…$`` and
-#: ``match``, Python's ``$`` also matches *before a trailing newline*, so
-#: ``"..\n"`` passed the charset test and then missed ``_DOT_SEGMENTS``
-#: (which compares whole strings) — smuggling a dot segment through the one
-#: check that exists to stop it. ``[^/]+`` in the route matches newlines too,
-#: so this was reachable as ``/linked-accounts/..%0A``.
+#: Keycloak aliases are hostname-shaped (``idp.acme.com``) and case-sensitive.
+#: ``/`` stays out: these are interpolated into the upstream URL and
+#: ``requests`` resolves dot segments, so a separator would let an alias form
+#: path segments of its own. ``fullmatch`` rather than ``^…$``, which also
+#: matches before a trailing newline.
 _PROVIDER_ALIAS_RE = re.compile(r"[a-zA-Z0-9._-]+")
 
 #: Segments ``requests`` would normalise away, walking the request out of
-#: ``/linked-accounts/`` and issuing it against the account root instead.
-#: Only meaningful as a *whole* alias — ``a..b`` is an ordinary segment.
+#: ``/linked-accounts/``. Only as a *whole* alias — ``a..b`` is ordinary.
 _DOT_SEGMENTS = frozenset({".", ".."})
 
 
@@ -74,13 +56,8 @@ def _is_valid_provider_alias(alias: str) -> bool:
     return bool(_PROVIDER_ALIAS_RE.fullmatch(alias)) and alias not in _DOT_SEGMENTS
 
 
-#: Keycloak session ids are UUIDs. The dot is deliberately excluded: these
-#: values are interpolated into the upstream URL, and ``requests`` resolves
-#: dot segments before sending, so a ``..`` here would walk out of
-#: ``/sessions/`` and issue the request against the account root instead.
-#: ``fullmatch`` for the same trailing-newline reason as the alias regex —
-#: harmless here (``.`` is outside the charset) but the two should not
-#: differ in rigour.
+#: Keycloak session ids are UUIDs. The dot is excluded for the same reason as
+#: above: a ``..`` here would walk out of ``/sessions/``.
 _SESSION_ID_RE = re.compile(r"[a-zA-Z0-9_-]+")
 
 

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -311,6 +311,16 @@ class KeycloakAccountMixin:
                 # that the distinction rarely matters.
                 return self._bad_gateway(exc, method, path_suffix)
             return Response(payload, status=status_code)
+        if status.is_redirect(status_code):
+            # We asked not to follow it, so it arrives here. Forwarding it
+            # verbatim would re-emit a redirect from our own origin with no
+            # Location -- and a 301 is cacheable. It is the same "not the
+            # account API answering" case as an unparseable body.
+            return self._bad_gateway(
+                UpstreamShapeError(f"account endpoint answered {status_code}"),
+                method,
+                path_suffix,
+            )
         return Response(
             {"error": "Identity provider rejected the request.", "upstream": body},
             status=status_code,

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -16,6 +16,7 @@ import logging
 import re
 from typing import Any, Callable, Optional, Tuple
 
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
 
@@ -122,6 +123,24 @@ class KeycloakAccountMixin:
     #: These actions call Keycloak as the signed-in user, so they need the
     #: token pair ``callback`` would otherwise drop.
     stash_oidc_tokens = True
+
+    def __init_subclass__(cls, **kwargs):
+        """Refuse a subclass that lists the mixin after the base viewset.
+
+        ``class V(UserModelOpenIDConnectViewset, KeycloakAccountMixin)`` is
+        the natural habit, and it resolves ``stash_oidc_tokens`` to the
+        base's ``False``. Every route is still generated and login still
+        succeeds, so the only symptom is that all proxy calls 401 forever.
+        Raising here makes it a startup error at class definition.
+        """
+        super().__init_subclass__(**kwargs)
+        if not cls.stash_oidc_tokens:
+            raise ImproperlyConfigured(
+                f"{cls.__name__} lists KeycloakAccountMixin after the base "
+                f"viewset, so stash_oidc_tokens resolves to False and the "
+                f"account proxy would answer 401 to everything. Put the "
+                f"mixin first: class {cls.__name__}(KeycloakAccountMixin, ...)."
+            )
 
     def _keycloak_account_request(
         self,

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -1,0 +1,492 @@
+"""
+Keycloak Account REST proxy.
+
+Keycloak-specific, and deliberately kept out of ``BaseOpenIDConnectViewset``:
+the paths proxied here (``/sessions``, ``/linked-accounts``, ``/credentials``)
+are Keycloak's own Account API, not anything OIDC standardises. Deployments
+opt in by routing to a viewset that mixes ``KeycloakAccountMixin`` in --
+see ``VIEWSET_CLASS`` -- and a deployment that does not gets no routes for
+these endpoints at all.
+
+This mirrors ``RapidProOpenIDConnectViewset``: provider-specific behaviour
+lives in a subclass, the base viewset stays provider-neutral.
+"""
+
+import logging
+import re
+from typing import Any, Callable, Optional, Tuple
+
+from django.http import HttpRequest, HttpResponse
+from django.utils.translation import gettext as _
+
+import jwt
+import requests
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+
+from oidc.client import EndpointNotConfigured, OpenIDClient, TokenVerificationFailed
+from oidc.permissions import IsCsrfSafeAccountRequest
+from oidc.utils import (
+    ACCESS_TOKEN_SESSION_KEY,
+    ID_TOKEN_SESSION_KEY,
+    REFRESH_TOKEN_SESSION_KEY,
+    token_session_key,
+)
+from oidc.viewsets import UserModelOpenIDConnectViewset
+
+logger = logging.getLogger(__name__)
+
+
+#: Keycloak identity-provider aliases routinely look like hostnames
+#: (``idp.acme.com`` — Keycloak itself builds ``brokerUserId`` as
+#: ``alias + "." + federatedUserId``) and are case-sensitive, so both the dot
+#: and uppercase belong in the charset. A lowercase-only allowlist without the
+#: dot silently 400s a correctly configured realm's IdP.
+#:
+#: ``/`` deliberately stays out. These values are interpolated into the
+#: upstream URL and ``requests`` resolves dot segments before sending, so a
+#: separator would let an alias form path segments of its own. With no
+#: separator available the only traversal left is an alias that is *entirely*
+#: a dot segment, rejected below.
+#:
+#: Aliases outside this charset (spaces, unicode) are refused rather than
+#: percent-encoded: they are vanishingly rare, and every character here is
+#: URL-unreserved, so encoding would be a no-op that only obscured the rule.
+#:
+#: Matched with ``fullmatch`` and deliberately unanchored: with ``^…$`` and
+#: ``match``, Python's ``$`` also matches *before a trailing newline*, so
+#: ``"..\n"`` passed the charset test and then missed ``_DOT_SEGMENTS``
+#: (which compares whole strings) — smuggling a dot segment through the one
+#: check that exists to stop it. ``[^/]+`` in the route matches newlines too,
+#: so this was reachable as ``/linked-accounts/..%0A``.
+_PROVIDER_ALIAS_RE = re.compile(r"[a-zA-Z0-9._-]+")
+
+#: Segments ``requests`` would normalise away, walking the request out of
+#: ``/linked-accounts/`` and issuing it against the account root instead.
+#: Only meaningful as a *whole* alias — ``a..b`` is an ordinary segment.
+_DOT_SEGMENTS = frozenset({".", ".."})
+
+
+def _is_valid_provider_alias(alias: str) -> bool:
+    """Whether ``alias`` is safe to interpolate into the Account REST path."""
+    return bool(_PROVIDER_ALIAS_RE.fullmatch(alias)) and alias not in _DOT_SEGMENTS
+
+
+#: Keycloak session ids are UUIDs. The dot is deliberately excluded: these
+#: values are interpolated into the upstream URL, and ``requests`` resolves
+#: dot segments before sending, so a ``..`` here would walk out of
+#: ``/sessions/`` and issue the request against the account root instead.
+#: ``fullmatch`` for the same trailing-newline reason as the alias regex —
+#: harmless here (``.`` is outside the charset) but the two should not
+#: differ in rigour.
+_SESSION_ID_RE = re.compile(r"[a-zA-Z0-9_-]+")
+
+
+def _sid_from_id_token(id_token: str) -> Optional[str]:
+    """Decode the ``sid`` claim from an id_token *without* verifying the
+    signature. The token was already verified at callback time and
+    stashed in the user's session; we only need the session-id claim
+    to power the revoke-current guard."""
+    try:
+        unverified = jwt.decode(id_token, options={"verify_signature": False})
+    except jwt.exceptions.InvalidTokenError:
+        return None
+    return unverified.get("sid")
+
+
+#: Single wording for "this request carries no usable OIDC session". The
+#: account proxy is driven by one SPA, so the same state must not surface
+#: three different strings depending on which endpoint was hit.
+NO_ACTIVE_SESSION = {"error": "No active OIDC session — please sign in again."}
+
+
+def _authenticated_session(request: HttpRequest, auth_server: Optional[str]):
+    """The request's session if it holds an access token *for ``auth_server``*.
+
+    Identity for the account proxy is the stashed token, not ``request.user``:
+    ona-oidc only calls Django's ``login()`` when ``USE_AUTH_BACKEND`` is on,
+    which is off by default, so there is no authenticated user to rely on.
+
+    Tokens are namespaced per provider, so a caller signed in to one provider
+    simply has no token here for another and is treated as having no session.
+    """
+    session = getattr(request, "session", None)
+    if session is None or not session.get(
+        token_session_key(ACCESS_TOKEN_SESSION_KEY, auth_server)
+    ):
+        return None
+    return session
+
+
+def _current_sid(request: HttpRequest, auth_server: Optional[str]) -> Optional[str]:
+    """The caller's Keycloak session id, from the id_token stashed at callback.
+
+    ``None`` when there is no session, no id_token for ``auth_server``, or no
+    ``sid`` claim.
+    """
+    session = getattr(request, "session", None)
+    if session is None:
+        return None
+    id_token = session.get(token_session_key(ID_TOKEN_SESSION_KEY, auth_server))
+    if not id_token:
+        return None
+    return _sid_from_id_token(id_token)
+
+
+class KeycloakAccountMixin:
+    """The Keycloak Account REST proxy actions.
+
+    Mix into a viewset deriving from ``BaseOpenIDConnectViewset``; it relies
+    on ``_get_client`` from there.
+    """
+
+    #: These actions call Keycloak as the signed-in user, so they need the
+    #: token pair ``callback`` would otherwise drop.
+    stash_oidc_tokens = True
+
+    def _keycloak_account_request(
+        self,
+        client: OpenIDClient,
+        session,
+        method: str,
+        path_suffix: str,
+    ) -> Tuple[int, Optional[dict]]:
+        """
+        Call Keycloak's Account REST API as the session's user,
+        refreshing the stashed token pair and retrying once on 401.
+
+        Returns ``(upstream_status, parsed_json_or_None)``; network
+        failures bubble up as ``RequestException`` for the caller to
+        map to 502.
+        """
+        # Read through ``client.auth_server`` rather than the route's kwarg:
+        # the client is the thing the tokens are about to be sent to, so
+        # keying off it is what makes a mismatch unrepresentable.
+        access_key = token_session_key(ACCESS_TOKEN_SESSION_KEY, client.auth_server)
+        refresh_key = token_session_key(REFRESH_TOKEN_SESSION_KEY, client.auth_server)
+
+        access_token = session.get(access_key)
+        if not access_token:
+            return status.HTTP_401_UNAUTHORIZED, NO_ACTIVE_SESSION
+
+        status_code, body = client.request_keycloak_account(
+            access_token, method, path_suffix
+        )
+        if status_code != status.HTTP_401_UNAUTHORIZED:
+            return status_code, body
+
+        refresh_token = session.get(refresh_key)
+        if not refresh_token:
+            return status.HTTP_401_UNAUTHORIZED, body
+
+        try:
+            tokens = client.refresh_access_token(refresh_token)
+        except TokenVerificationFailed:
+            return (
+                status.HTTP_401_UNAUTHORIZED,
+                {"error": "Session expired — please sign in again."},
+            )
+
+        new_access = tokens.get("access_token")
+        new_refresh = tokens.get("refresh_token")
+        if new_access:
+            session[access_key] = new_access
+        if new_refresh:
+            session[refresh_key] = new_refresh
+        if not new_access:
+            return status.HTTP_401_UNAUTHORIZED, body
+        return client.request_keycloak_account(new_access, method, path_suffix)
+
+    def _proxy_or_error(
+        self,
+        request: HttpRequest,
+        auth_server,
+        method: str,
+        path_suffix: str,
+        transform: Optional[Callable[[Any], Any]] = None,
+    ) -> HttpResponse:
+        """
+        Shared wrapper for the proxy actions. ``transform`` runs on the
+        parsed body so per-endpoint normalisation stays close to the
+        action that needs it.
+        """
+        client = self._get_client(auth_server=auth_server)
+        if client is None:
+            # A DRF Response, not HttpResponseBadRequest: these actions
+            # render JSON only, and an HTML body here is the one error the
+            # SPA cannot read the message out of.
+            return Response(
+                {"error": _("Unknown auth server.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not client.account_endpoint:
+            return Response(
+                {"error": "Account endpoint not configured."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        session = _authenticated_session(request, client.auth_server)
+        if session is None:
+            return Response(NO_ACTIVE_SESSION, status=status.HTTP_401_UNAUTHORIZED)
+        try:
+            status_code, body = self._keycloak_account_request(
+                client, session, method, path_suffix
+            )
+        except EndpointNotConfigured as exc:
+            # A missing ACCOUNT_ENDPOINT or TOKEN_ENDPOINT is our own
+            # configuration gap, not the IdP being down. Reporting it as a
+            # bad gateway points the investigation at Keycloak, where there
+            # is nothing to find. Deliberately not bare ValueError: a
+            # malformed IdP response raises JSONDecodeError, which is one
+            # too, and that is upstream's problem rather than our config.
+            logger.exception(exc)
+            return Response(
+                {"error": "Identity provider is not fully configured."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        except requests.RequestException as exc:
+            # Genuinely upstream: the IdP could not be reached. Catching bare
+            # Exception here would report a bug in our own transform/flatten
+            # code as "the IdP is unreachable" and send the investigation to
+            # Keycloak instead of to us.
+            logger.exception(exc)
+            return Response(
+                {"error": "Could not reach the identity provider."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+        if status.is_success(status_code):
+            payload = transform(body) if transform else body
+            return Response(payload, status=status_code)
+        return Response(
+            {"error": "Identity provider rejected the request.", "upstream": body},
+            status=status_code,
+        )
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="sessions",
+        url_name="openid_connect_sessions",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
+    def sessions_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """
+        List the user's active Keycloak sessions. Flattens
+        Keycloak's per-device representation into one row per
+        session so the SPA renders a flat list.
+        """
+        # Pin ``current`` to the id_token's ``sid`` claim — Keycloak's
+        # device-level flag marks every same-machine session current
+        # (see _flatten_session_devices).
+        current_sid = _current_sid(request, kwargs.get("auth_server"))
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            "/sessions/devices",
+            transform=lambda body: self._flatten_session_devices(body, current_sid),
+        )
+
+    @action(
+        methods=["DELETE"],
+        detail=False,
+        url_path=r"sessions/(?P<session_id>[a-zA-Z0-9._-]+)",
+        url_name="openid_connect_sessions_revoke_one",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
+    def sessions_revoke_one(
+        self, request: HttpRequest, session_id: str = "", **kwargs: dict
+    ) -> HttpResponse:
+        """Revoke one Keycloak session by id. Rejects the user's current
+        session (defence in depth — the SPA already blocks this at the
+        button level)."""
+        if not _SESSION_ID_RE.fullmatch(session_id):
+            return Response(
+                {"error": "Invalid session id."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        current_sid = _current_sid(request, kwargs.get("auth_server"))
+        if current_sid and current_sid == session_id:
+            return Response(
+                {
+                    "error": (
+                        "Cannot revoke the current session via this "
+                        "endpoint; use sign-out instead."
+                    )
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "DELETE",
+            f"/sessions/{session_id}",
+        )
+
+    # Shares ``sessions_list``'s route rather than declaring its own: two
+    # actions on the same path would generate two identical patterns, and
+    # Django would resolve the first — leaving DELETE with a silent 405.
+    # Note this also inherits sessions_list's view kwargs, so the CSRF gate
+    # on this endpoint is configured there, not here.
+    @sessions_list.mapping.delete
+    def sessions_revoke_others(
+        self, request: HttpRequest, **kwargs: dict
+    ) -> HttpResponse:
+        """Revoke every Keycloak session except the current one."""
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "DELETE",
+            "/sessions?current=false",
+        )
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="linked-accounts",
+        url_name="openid_connect_linked_list",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
+    def linked_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """List broker IdPs configured on the realm with their connected
+        state for the current user."""
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            "/linked-accounts",
+        )
+
+    @action(
+        methods=["DELETE"],
+        detail=False,
+        url_path=r"linked-accounts/(?P<provider>[^/]+)",
+        url_name="openid_connect_linked_unlink",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
+    def linked_unlink(
+        self, request: HttpRequest, provider: str = "", **kwargs: dict
+    ) -> HttpResponse:
+        """Unlink a broker IdP from the current user."""
+        if not _is_valid_provider_alias(provider):
+            return Response(
+                {"error": "Invalid provider alias."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "DELETE",
+            f"/linked-accounts/{provider}",
+        )
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"linked-accounts/(?P<provider>[^/]+)/link-url",
+        url_name="openid_connect_linked_link_url",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
+    def linked_link_url(
+        self, request: HttpRequest, provider: str = "", **kwargs: dict
+    ) -> HttpResponse:
+        """Get Keycloak's linked-account representation for
+        ``provider``, forwarded verbatim. Its ``accountLinkUri`` is the
+        one-shot URL the SPA opens in a new tab to drive the
+        broker-link flow."""
+        if not _is_valid_provider_alias(provider):
+            return Response(
+                {"error": "Invalid provider alias."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            f"/linked-accounts/{provider}",
+        )
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="credentials",
+        url_name="openid_connect_credentials",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
+    def credentials_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """List credential metadata (TOTP / password / recovery codes).
+
+        Keycloak's nested wire shape (instances under
+        ``userCredentialMetadatas`` → ``credential``) is forwarded
+        verbatim — reshaping for rendering happens client-side in the
+        SPA.
+        """
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            "/credentials",
+        )
+
+    @staticmethod
+    def _flatten_session_devices(
+        body: Optional[list], current_sid: Optional[str] = None
+    ) -> list:
+        """``[{os, device, current, sessions:[{id, browser, ...}, ...]}, ...]``
+        → ``[{id, browser, os, started, ...}, ...]``.
+
+        Field placement matters: Keycloak's ``DeviceRepresentation`` carries
+        ``os``/``osVersion``/``device`` at the device level, but ``browser``
+        lives on each nested ``SessionRepresentation`` (two browsers on one
+        machine group under the same device, each its own session). So read
+        ``browser`` from the session, not the device.
+
+        ``current_sid`` is the ``sid`` claim from the caller's stashed
+        id_token; when known, a session is current iff its id matches.
+        Keycloak groups sessions by device fingerprint (OS + browser +
+        IP) and flags the *device* current, so two browsers on one
+        machine both read as current from Keycloak's own flags — the
+        SPA rendered exactly that bug. Falls back to Keycloak's flags
+        only when the sid is unavailable."""
+        if not body:
+            return []
+        rows: list = []
+        for device in body:
+            os_name = device.get("os")
+            device_current = bool(device.get("current"))
+            for sess in device.get("sessions", []) or []:
+                sid = sess.get("id")
+                if current_sid:
+                    is_current = sid == current_sid
+                else:
+                    is_current = bool(sess.get("current", device_current))
+                rows.append(
+                    {
+                        "id": sid,
+                        "browser": sess.get("browser"),
+                        "os": os_name,
+                        "ipAddress": sess.get("ipAddress"),
+                        "started": sess.get("started"),
+                        "lastAccess": sess.get("lastAccess"),
+                        "current": is_current,
+                        "clients": sess.get("clients", []),
+                    }
+                )
+        return rows
+
+
+class KeycloakOpenIDConnectViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """The default viewset plus the Keycloak Account REST proxy."""

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -319,7 +319,7 @@ class KeycloakAccountMixin:
     @action(
         methods=["GET"],
         detail=False,
-        url_path="sessions",
+        url_path=r"sessions/?",
         url_name="openid_connect_sessions",
         authentication_classes=[],
         permission_classes=[IsCsrfSafeAccountRequest],
@@ -346,7 +346,7 @@ class KeycloakAccountMixin:
     @action(
         methods=["DELETE"],
         detail=False,
-        url_path=r"sessions/(?P<session_id>[a-zA-Z0-9._-]+)",
+        url_path=r"sessions/(?P<session_id>[a-zA-Z0-9._-]+)/?",
         url_name="openid_connect_sessions_revoke_one",
         authentication_classes=[],
         permission_classes=[IsCsrfSafeAccountRequest],
@@ -401,7 +401,7 @@ class KeycloakAccountMixin:
     @action(
         methods=["GET"],
         detail=False,
-        url_path="linked-accounts",
+        url_path=r"linked-accounts/?",
         url_name="openid_connect_linked_list",
         authentication_classes=[],
         permission_classes=[IsCsrfSafeAccountRequest],
@@ -421,7 +421,7 @@ class KeycloakAccountMixin:
     @action(
         methods=["DELETE"],
         detail=False,
-        url_path=r"linked-accounts/(?P<provider>[^/]+)",
+        url_path=r"linked-accounts/(?P<provider>[^/]+)/?",
         url_name="openid_connect_linked_unlink",
         authentication_classes=[],
         permission_classes=[IsCsrfSafeAccountRequest],
@@ -446,7 +446,7 @@ class KeycloakAccountMixin:
     @action(
         methods=["GET"],
         detail=False,
-        url_path=r"linked-accounts/(?P<provider>[^/]+)/link-url",
+        url_path=r"linked-accounts/(?P<provider>[^/]+)/link-url/?",
         url_name="openid_connect_linked_link_url",
         authentication_classes=[],
         permission_classes=[IsCsrfSafeAccountRequest],
@@ -475,7 +475,7 @@ class KeycloakAccountMixin:
     @action(
         methods=["GET"],
         detail=False,
-        url_path="credentials",
+        url_path=r"credentials/?",
         url_name="openid_connect_credentials",
         authentication_classes=[],
         permission_classes=[IsCsrfSafeAccountRequest],

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Optional, Tuple
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 import jwt
 import requests
@@ -82,7 +83,9 @@ def _sid_from_id_token(id_token: str) -> Optional[str]:
 #: Single wording for "this request carries no usable OIDC session". The
 #: account proxy is driven by one SPA, so the same state must not surface
 #: three different strings depending on which endpoint was hit.
-NO_ACTIVE_SESSION = {"error": "No active OIDC session — please sign in again."}
+NO_ACTIVE_SESSION = {
+    "error": gettext_lazy("No active OIDC session — please sign in again.")
+}
 
 
 def _authenticated_session(request: HttpRequest, auth_server: Optional[str]):
@@ -205,7 +208,7 @@ class KeycloakAccountMixin:
         except TokenVerificationFailed:
             return (
                 status.HTTP_401_UNAUTHORIZED,
-                {"error": "Session expired — please sign in again."},
+                {"error": _("Session expired — please sign in again.")},
             )
 
         new_access = tokens.get("access_token")
@@ -223,7 +226,7 @@ class KeycloakAccountMixin:
         """The IdP answered, but not with anything we can use."""
         logger.exception("account proxy %s %s: %s", method, path_suffix, exc)
         return Response(
-            {"error": "Unexpected response from the identity provider."},
+            {"error": _("Unexpected response from the identity provider.")},
             status=status.HTTP_502_BAD_GATEWAY,
         )
 
@@ -262,7 +265,7 @@ class KeycloakAccountMixin:
             return Response(NO_ACTIVE_SESSION, status=status.HTTP_401_UNAUTHORIZED)
         if not client.account_endpoint:
             return Response(
-                {"error": "Account endpoint not configured."},
+                {"error": _("Account endpoint not configured.")},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         try:
@@ -278,7 +281,7 @@ class KeycloakAccountMixin:
             # too, and that is upstream's problem rather than our config.
             logger.exception(exc)
             return Response(
-                {"error": "Identity provider is not fully configured."},
+                {"error": _("Identity provider is not fully configured.")},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         except requests.RequestException as exc:
@@ -288,7 +291,7 @@ class KeycloakAccountMixin:
             # Keycloak instead of to us.
             logger.exception(exc)
             return Response(
-                {"error": "Could not reach the identity provider."},
+                {"error": _("Could not reach the identity provider.")},
                 status=status.HTTP_502_BAD_GATEWAY,
             )
         except UpstreamShapeError as exc:
@@ -322,7 +325,7 @@ class KeycloakAccountMixin:
                 path_suffix,
             )
         return Response(
-            {"error": "Identity provider rejected the request.", "upstream": body},
+            {"error": _("Identity provider rejected the request."), "upstream": body},
             status=status_code,
         )
 
@@ -370,7 +373,7 @@ class KeycloakAccountMixin:
         button level)."""
         if not _SESSION_ID_RE.fullmatch(session_id):
             return Response(
-                {"error": "Invalid session id."},
+                {"error": _("Invalid session id.")},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         current_sid = _current_sid(request, kwargs.get("auth_server"))
@@ -443,7 +446,7 @@ class KeycloakAccountMixin:
         """Unlink a broker IdP from the current user."""
         if not _is_valid_provider_alias(provider):
             return Response(
-                {"error": "Invalid provider alias."},
+                {"error": _("Invalid provider alias.")},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return self._proxy_or_error(
@@ -471,7 +474,7 @@ class KeycloakAccountMixin:
         broker-link flow."""
         if not _is_valid_provider_alias(provider):
             return Response(
-                {"error": "Invalid provider alias."},
+                {"error": _("Invalid provider alias.")},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return self._proxy_or_error(

--- a/oidc/keycloak.py
+++ b/oidc/keycloak.py
@@ -134,13 +134,31 @@ class KeycloakAccountMixin:
         Raising here makes it a startup error at class definition.
         """
         super().__init_subclass__(**kwargs)
-        if not cls.stash_oidc_tokens:
-            raise ImproperlyConfigured(
-                f"{cls.__name__} lists KeycloakAccountMixin after the base "
-                f"viewset, so stash_oidc_tokens resolves to False and the "
-                f"account proxy would answer 401 to everything. Put the "
-                f"mixin first: class {cls.__name__}(KeycloakAccountMixin, ...)."
+        if cls.stash_oidc_tokens:
+            return
+        # Two ways to get here, and they need different advice: the mixin
+        # sitting after a base that defines the attribute (so the base wins),
+        # or someone setting it False outright.
+        mro = cls.__mro__
+        shadowed = any(
+            "stash_oidc_tokens" in vars(klass)
+            for klass in mro[1 : mro.index(KeycloakAccountMixin)]
+        )
+        if shadowed:
+            remedy = (
+                f"Put the mixin first: "
+                f"class {cls.__name__}(KeycloakAccountMixin, ...)."
             )
+        else:
+            remedy = (
+                "Drop the explicit stash_oidc_tokens = False, or drop the "
+                "mixin if this viewset should not serve the proxy."
+            )
+        raise ImproperlyConfigured(
+            f"{cls.__name__} mixes in KeycloakAccountMixin but resolves "
+            f"stash_oidc_tokens to False, so the account proxy would answer "
+            f"401 to everything. {remedy}"
+        )
 
     def _keycloak_account_request(
         self,

--- a/oidc/permissions.py
+++ b/oidc/permissions.py
@@ -1,0 +1,69 @@
+"""
+Cross-origin protection for the cookie-identified Keycloak Account REST proxy.
+
+The proxy actions take the caller's identity from the OIDC tokens stashed in
+``request.session`` (a cookie), and run with ``authentication_classes=[]`` —
+so DRF's ``SessionAuthentication`` CSRF check does not apply. Two in-code
+checks stand in for it, so the boundary holds whatever the deployment's CORS
+config says:
+
+  * Every method enforces the ``Origin`` allowlist (the trusted first-party
+    SPA hosts; a missing ``Origin`` — same-origin requests may omit it — is
+    allowed). For *writes* this rejects a cross-origin page that sets the
+    custom header via ``fetch``. For *reads* it is what closes the leak: the
+    only way a cross-origin page can read one of these listings is a
+    credentialed CORS ``fetch`` against a deployment whose CORS reflects
+    arbitrary origins, and that fetch always carries ``Origin`` — so it is
+    refused here, server-side, before Keycloak is ever called.
+  * Unsafe methods additionally require a custom header that cross-site
+    markup (``<form>``, ``<img>``, navigation) cannot set — so markup can't
+    forge writes at all. Reads deliberately do *not* require it: markup GETs
+    cannot read a JSON response in any current browser, so a header check on
+    reads adds nothing the ``Origin`` check does not, and the SPA sends the
+    header only on writes.
+
+Neither check depends on the session cookie's ``SameSite`` attribute (kept
+as ``Lax`` + ``Secure`` as an additional layer), so the protection holds
+even when a cross-site SPA forces ``SameSite=None`` to send credentials.
+Keeping the account host out of any permissive ``CORS_ALLOW_ALL_ORIGINS`` /
+regex allowlist remains good hygiene, but is no longer load-bearing.
+"""
+
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+import oidc.settings as default
+from oidc.utils import get_viewset_config, is_allowed_account_origin
+
+_default_config = getattr(default, "OPENID_CONNECT_VIEWSET_CONFIG", {})
+
+
+def get_account_request_header() -> str:
+    """The header the SPA must send on state-changing account-proxy requests.
+
+    Configurable via ``OPENID_CONNECT_VIEWSET_CONFIG["ACCOUNT_REQUEST_HEADER"]``
+    so deployments outside Ona are not stuck advertising an ``X-Ona-`` header.
+    Any value works as a CSRF defence: what matters is that cross-site markup
+    cannot set a custom header at all, not which name is used.
+    """
+    return get_viewset_config().get(
+        "ACCOUNT_REQUEST_HEADER", _default_config["ACCOUNT_REQUEST_HEADER"]
+    )
+
+
+class IsCsrfSafeAccountRequest(BasePermission):
+    @property
+    def message(self):
+        # Resolved per request, not at import: a class-level f-string would
+        # freeze the default and keep naming X-Ona-Account-Request after a
+        # deployment configured something else.
+        return (
+            f"Account requests must come from a trusted origin; state-changing "
+            f"ones must also include the {get_account_request_header()} header."
+        )
+
+    def has_permission(self, request, view):
+        if not is_allowed_account_origin(view.kwargs.get("auth_server"), request):
+            return False
+        if request.method in SAFE_METHODS:
+            return True
+        return bool(request.headers.get(get_account_request_header()))

--- a/oidc/routers.py
+++ b/oidc/routers.py
@@ -2,19 +2,30 @@
 Routers used to build this package's URLs.
 """
 
-from rest_framework.routers import SimpleRouter
+from rest_framework.routers import DynamicRoute, SimpleRouter
 
 
 class UnprefixedNameRouter(SimpleRouter):
-    """A router that names routes ``{url_name}``, not ``{basename}-{url_name}``.
+    """A router that names ``@action`` routes ``{url_name}``, not
+    ``{basename}-{url_name}``.
 
     ``reverse("oidc:openid_connect_login")`` is part of this package's public
     surface — used by the unrecoverable-error template and by consumers — so
     the names the hand-written URLconf declared have to survive. A stock
     router would rename that route to ``oidc-openid_connect_login``.
+
+    Only the dynamic routes: every name this package publishes comes from an
+    ``@action``, while ``{basename}-list``/``-detail`` belong to DRF's own
+    conventions. Stripping those too would rename a ``VIEWSET_CLASS`` with
+    CRUD methods to a bare ``list``/``detail``, which collides across
+    routers and breaks hyperlinked serializers reversing ``<model>-detail``.
     """
 
     routes = [
-        route._replace(name=route.name.replace("{basename}-", ""))
+        (
+            route._replace(name=route.name.replace("{basename}-", ""))
+            if isinstance(route, DynamicRoute)
+            else route
+        )
         for route in SimpleRouter.routes
     ]

--- a/oidc/routers.py
+++ b/oidc/routers.py
@@ -1,0 +1,20 @@
+"""
+Routers used to build this package's URLs.
+"""
+
+from rest_framework.routers import SimpleRouter
+
+
+class UnprefixedNameRouter(SimpleRouter):
+    """A router that names routes ``{url_name}``, not ``{basename}-{url_name}``.
+
+    ``reverse("oidc:openid_connect_login")`` is part of this package's public
+    surface — used by the unrecoverable-error template and by consumers — so
+    the names the hand-written URLconf declared have to survive. A stock
+    router would rename that route to ``oidc-openid_connect_login``.
+    """
+
+    routes = [
+        route._replace(name=route.name.replace("{basename}-", ""))
+        for route in SimpleRouter.routes
+    ]

--- a/oidc/settings.py
+++ b/oidc/settings.py
@@ -3,6 +3,10 @@ Settings Module for the oidc App
 """
 
 OPENID_CONNECT_VIEWSET_CONFIG = {
+    # Dotted path to the viewset oidc.urls routes to. Unset means the
+    # built-in one; set it to route to a project-owned subclass.
+    "VIEWSET_CLASS": None,
+    "ACCOUNT_REQUEST_HEADER": "X-Ona-Account-Request",
     "REQUIRED_USER_CREATION_FIELDS": ["email", "first_name", "username"],
     "USER_CREATION_FIELDS": ["email", "first_name", "last_name", "username"],
     "USER_DEFAULTS": {},
@@ -41,6 +45,8 @@ OPENID_CONNECT_AUTH_SERVERS = {
         "VERIFY_ACCESS_TOKEN": True,
         "NONCE_CACHE_TIMEOUT": 1800,
         "USE_PKCE": False,
+        # (connect, read) seconds for every outbound call to this IdP.
+        "REQUEST_TIMEOUT": (5, 15),
         "PKCE_CODE_CHALLENGE_METHOD": "S256",
         "PKCE_CODE_CHALLENGE_TIMEOUT": 600,
         "PKCE_CODE_VERIFIER_LENGTH": 64,

--- a/oidc/templates/base.html
+++ b/oidc/templates/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+{% comment %}
+Fallback only. The two pages this package renders in a browser -- the
+username-entry form and the unrecoverable-error page -- extend 'base.html',
+and without one anywhere on the template path they raise
+TemplateDoesNotExist and the user gets a bare 500 instead.
+
+A project's own base.html wins: TEMPLATES["DIRS"] is searched before any app
+directory, and among app directories the INSTALLED_APPS order decides, so
+list "oidc" after the app that provides yours. It only has to define the
+title and content blocks below.
+{% endcomment %}
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}{% endblock %}</title>
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/oidc/templates/oidc/oidc_unrecoverable_error.html
+++ b/oidc/templates/oidc/oidc_unrecoverable_error.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="content">
     <div class="content-body">
-        <p class="error-message">{{ error }}</a></p>
+        <p class="error-message">{{ error }}</p>
         {% if login_url %}
         <p>Something went wrong, please try again later - <a href="{{ login_url }}">login</a>.</p>
         {% endif %}

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -33,8 +33,40 @@ urlpatterns = [
         name="openid_connect_logout",
     ),
     re_path(
-        r"^oidc/(?P<auth_server>\w+)/account",
+        r"^oidc/(?P<auth_server>\w+)/account$",
         viewset_class.as_view({"post": "account"}),
         name="openid_connect_account",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/sessions$",
+        viewset_class.as_view(
+            {"get": "sessions_list", "delete": "sessions_revoke_others"}
+        ),
+        name="openid_connect_sessions",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/sessions/(?P<session_id>[a-zA-Z0-9._-]+)$",
+        viewset_class.as_view({"delete": "sessions_revoke_one"}),
+        name="openid_connect_sessions_revoke_one",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/linked-accounts$",
+        viewset_class.as_view({"get": "linked_list"}),
+        name="openid_connect_linked_list",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/linked-accounts/(?P<provider>[^/]+)/link-url$",
+        viewset_class.as_view({"get": "linked_link_url"}),
+        name="openid_connect_linked_link_url",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/linked-accounts/(?P<provider>[^/]+)$",
+        viewset_class.as_view({"delete": "linked_unlink"}),
+        name="openid_connect_linked_unlink",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/credentials$",
+        viewset_class.as_view({"get": "credentials_list"}),
+        name="openid_connect_credentials",
     ),
 ]

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -31,15 +31,10 @@ def get_viewset_class():
     return UserModelOpenIDConnectViewset
 
 
-# Routes come from the @action decorators, so each action carries its own
-# url_path, url_name and view kwargs — including the account-proxy CSRF gate,
-# which previously had to be repeated per route here and re-mirrored by every
-# consumer that declared its own URLconf.
-#
+# Every route's url_path, url_name and view kwargs — including the
+# account-proxy CSRF gate — come from the @action decorators.
 # trailing_slash=False keeps paths as /oidc/<server>/login rather than
-# /login/; the entry-point actions opt back into an optional trailing slash
-# individually. auth_server is captured by the prefix, which the router
-# interpolates into every generated pattern.
+# /login/; each action opts back into an optional trailing slash itself.
 router = UnprefixedNameRouter(trailing_slash=False)
 router.register(r"oidc/(?P<auth_server>\w+)", get_viewset_class(), basename="oidc")
 

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -3,44 +3,44 @@ URL Configuration file for ona-oidc
 """
 
 from django.conf import settings
-from django.urls import re_path
+from django.utils.module_loading import import_string
 
-from rest_framework.renderers import JSONRenderer
-
+from oidc.routers import UnprefixedNameRouter
 from oidc.utils import str_to_bool
 from oidc.viewsets import RapidProOpenIDConnectViewset, UserModelOpenIDConnectViewset
 
 app_name = "oidc"
 
-viewset_class = UserModelOpenIDConnectViewset
 
-config = getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", {})
-if str_to_bool(config.get("USE_RAPIDPRO_VIEWSET", False)):
-    viewset_class = RapidProOpenIDConnectViewset
+def get_viewset_class():
+    """The viewset these URLs route to.
 
-urlpatterns = [
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/login",
-        viewset_class.as_view({"get": "login"}),
-        name="openid_connect_login",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/callback",
-        viewset_class.as_view({"get": "callback", "post": "callback"}),
-        name="openid_connect_callback",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/logout",
-        viewset_class.as_view({"get": "logout"}),
-        name="openid_connect_logout",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/session",
-        viewset_class.as_view(
-            {"get": "session"},
-            authentication_classes=[],
-            renderer_classes=[JSONRenderer],
-        ),
-        name="openid_connect_session",
-    ),
-]
+    ``VIEWSET_CLASS`` (a dotted path) lets a deployment route to its own
+    subclass while still using ``include("oidc.urls")``. Without it, changing
+    this one name means copying the whole URLconf, and then mirroring every
+    route by hand, forever.
+
+    ``USE_RAPIDPRO_VIEWSET`` is the older boolean form and still works.
+    """
+    config = getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", {})
+    dotted_path = config.get("VIEWSET_CLASS")
+    if dotted_path:
+        return import_string(dotted_path)
+    if str_to_bool(config.get("USE_RAPIDPRO_VIEWSET", False)):
+        return RapidProOpenIDConnectViewset
+    return UserModelOpenIDConnectViewset
+
+
+# Routes come from the @action decorators, so each action carries its own
+# url_path, url_name and view kwargs — including the account-proxy CSRF gate,
+# which previously had to be repeated per route here and re-mirrored by every
+# consumer that declared its own URLconf.
+#
+# trailing_slash=False keeps paths as /oidc/<server>/login rather than
+# /login/; the entry-point actions opt back into an optional trailing slash
+# individually. auth_server is captured by the prefix, which the router
+# interpolates into every generated pattern.
+router = UnprefixedNameRouter(trailing_slash=False)
+router.register(r"oidc/(?P<auth_server>\w+)", get_viewset_class(), basename="oidc")
+
+urlpatterns = router.urls

--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -1,8 +1,10 @@
+import logging
 from typing import Iterable, Optional
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import DisallowedHost, ImproperlyConfigured
 from django.http import HttpRequest
 from django.utils.http import url_has_allowed_host_and_scheme
 
@@ -10,6 +12,8 @@ import jwt
 from jwt.exceptions import InvalidSignatureError
 
 import oidc.settings as default
+
+logger = logging.getLogger(__name__)
 
 
 def authenticate_sso(request, unique_user_field: str = "email"):
@@ -65,6 +69,140 @@ def get_viewset_config():
     return getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", default_config)
 
 
+#: Base names of the OIDC tokens ``callback`` stashes in the Django session.
+#: Never used as session keys directly — see ``token_session_key``.
+ACCESS_TOKEN_SESSION_KEY = "oidc_access_token"
+REFRESH_TOKEN_SESSION_KEY = "oidc_refresh_token"
+ID_TOKEN_SESSION_KEY = "oidc_id_token"
+
+
+def token_session_key(base_key: str, auth_server: Optional[str]) -> str:
+    """Session key for ``base_key``, namespaced to the issuing ``auth_server``.
+
+    ``OPENID_CONNECT_AUTH_SERVERS`` is a keyed dict and every key gets its own
+    routes, so the URL picks the provider while the session holds the tokens.
+    Stored under one global name, those tokens are readable from *every*
+    provider's route: a request to provider B replays provider A's access
+    token against B's account endpoint, and — because B answers a foreign
+    token with 401, which the retry path reads as "expired" — goes on to POST
+    A's long-lived refresh token to B's token endpoint. The same applies to
+    the id_token, which logout replays as ``id_token_hint``.
+
+    Namespacing makes that structurally impossible rather than merely
+    checked: B's slot is empty, which every caller already treats as "no
+    session". A guard would work too, but only for as long as each new call
+    site remembers it.
+
+    Deliberately no fallback to the un-namespaced key — reading it would
+    reinstate the very path this closes. Sessions predating this take one
+    401 and sign in again, the same fallback legacy sessions already hit.
+    """
+    return f"{base_key}:{auth_server}"
+
+
+#: The three slots ``callback`` fills and ``logout`` clears, in one place so
+#: the two cannot drift.
+TOKEN_SESSION_BASE_KEYS = (
+    ACCESS_TOKEN_SESSION_KEY,
+    REFRESH_TOKEN_SESSION_KEY,
+    ID_TOKEN_SESSION_KEY,
+)
+
+
+def pending_token_session_key(base_key: str, auth_server: Optional[str]) -> str:
+    """Session key for a token parked across the username-form round trip.
+
+    This exists for exactly one flow. When the IdP's claims carry no usable
+    username, ``callback`` answers with an entry form and the browser
+    re-POSTs it carrying only the ``id_token`` — so the access/refresh pair
+    the first request obtained from the token endpoint has to survive in the
+    session until the resubmit, where it is finally earned.
+
+    Nothing else uses pending slots: every other path writes the active
+    slots directly on the success exit. That is deliberate. Writing pending
+    on *every* callback and clearing it on the refusal exits would mean a
+    cleanup call each future exit has to remember, and a forgotten one
+    leaves a live refresh token at rest in the session store belonging to a
+    caller the deployment refused — who, never having signed in, will never
+    log out to clear it. Writing it only where it is needed removes the
+    obligation instead of distributing it.
+    """
+    return f"{token_session_key(base_key, auth_server)}:pending"
+
+
+def stash_pending_tokens(
+    session,
+    auth_server: Optional[str],
+    id_token: Optional[str],
+    access_token: Optional[str],
+    refresh_token: Optional[str],
+) -> None:
+    """Park a token pair for the username-form round trip.
+
+    ``id_token`` is stored alongside as the pair's owner — see
+    ``take_pending_tokens`` for why that matters.
+
+    All three slots are written as a unit, clearing rather than skipping an
+    absent value. Skipping would break the owner tag's whole guarantee: a
+    second flow whose token response carries no refresh token would
+    overwrite the id and access slots while *inheriting* the first flow's
+    refresh token, and the tag — now naming the second flow — would wave
+    the mismatched pair straight through.
+    """
+    if session is None or not access_token:
+        return
+    for base_key, value in (
+        (ID_TOKEN_SESSION_KEY, id_token),
+        (ACCESS_TOKEN_SESSION_KEY, access_token),
+        (REFRESH_TOKEN_SESSION_KEY, refresh_token),
+    ):
+        key = pending_token_session_key(base_key, auth_server)
+        if value:
+            session[key] = value
+        else:
+            session.pop(key, None)
+
+
+def take_pending_tokens(session, auth_server: Optional[str], id_token: Optional[str]):
+    """Pop the parked pair, but only if it belongs to ``id_token``.
+
+    Pending slots are keyed per provider, while a single Django session can
+    be running two logins at once — two tabs, same cookie. Both write the
+    same slots, so the pair sitting there when a form is submitted is not
+    necessarily the one that flow started with.
+
+    Handing back a mismatched pair would sign the browser in as one identity
+    while the account proxy authenticated to Keycloak as another: the SPA
+    would show identity X, and ``sessions_list`` / ``credentials_list`` /
+    ``sessions_revoke_one`` would all operate on identity Y's Keycloak
+    account. So a mismatch is dropped rather than used — the login still
+    completes, and the proxy answers 401 until the next full sign-in.
+
+    Always drains all three slots, match or not: a pair that has been
+    refused once must not sit there to be offered to the next login. That
+    also makes the success exit self-cleaning for a login abandoned at the
+    form, whose pair nothing else would ever remove.
+
+    Returns ``(access_token, refresh_token)``, either of which may be None.
+    """
+    if session is None:
+        return None, None
+    owner = session.pop(
+        pending_token_session_key(ID_TOKEN_SESSION_KEY, auth_server), None
+    )
+    access_token = session.pop(
+        pending_token_session_key(ACCESS_TOKEN_SESSION_KEY, auth_server), None
+    )
+    refresh_token = session.pop(
+        pending_token_session_key(REFRESH_TOKEN_SESSION_KEY, auth_server), None
+    )
+    if not owner or owner != id_token or not access_token:
+        # A lone refresh token is never usable on its own, and handing one
+        # back would write an active refresh with no matching access token.
+        return None, None
+    return access_token, refresh_token
+
+
 def _coerce_string_iterable(value, key: str, auth_server: str) -> Iterable[str]:
     """Reject string configs for list-typed settings.
 
@@ -80,6 +218,17 @@ def _coerce_string_iterable(value, key: str, auth_server: str) -> Iterable[str]:
     return value
 
 
+def _server_setting_values(auth_server: str, key: str) -> Iterable[str]:
+    """Validated string values of ``key`` for ``auth_server``; empty when unset.
+
+    Keeps ``key`` named once per call site — it is otherwise repeated as both
+    the lookup and the error label, which drift apart under rename.
+    """
+    config = getattr(settings, "OPENID_CONNECT_AUTH_SERVERS", {})
+    server_config = config.get(auth_server, {})
+    return _coerce_string_iterable(server_config.get(key, ()), key, auth_server)
+
+
 def get_login_query_param_allowlist(auth_server: str) -> frozenset[str]:
     """
     Return the set of query parameter names that the login view is allowed to
@@ -90,15 +239,7 @@ def get_login_query_param_allowlist(auth_server: str) -> frozenset[str]:
     Defaults to an empty set so unknown query params are dropped at the
     viewset boundary.
     """
-    config = getattr(settings, "OPENID_CONNECT_AUTH_SERVERS", {})
-    server_config = config.get(auth_server, {})
-    return frozenset(
-        _coerce_string_iterable(
-            server_config.get("LOGIN_QUERY_PARAM_ALLOWLIST", ()),
-            "LOGIN_QUERY_PARAM_ALLOWLIST",
-            auth_server,
-        )
-    )
+    return frozenset(_server_setting_values(auth_server, "LOGIN_QUERY_PARAM_ALLOWLIST"))
 
 
 def get_logout_query_param_allowlist(auth_server: str) -> frozenset[str]:
@@ -111,15 +252,38 @@ def get_logout_query_param_allowlist(auth_server: str) -> frozenset[str]:
     Defaults to an empty set so unknown query params are dropped at the
     viewset boundary — matches the ``LOGIN_QUERY_PARAM_ALLOWLIST`` shape.
     """
-    config = getattr(settings, "OPENID_CONNECT_AUTH_SERVERS", {})
-    server_config = config.get(auth_server, {})
     return frozenset(
-        _coerce_string_iterable(
-            server_config.get("LOGOUT_QUERY_PARAM_ALLOWLIST", ()),
-            "LOGOUT_QUERY_PARAM_ALLOWLIST",
+        _server_setting_values(auth_server, "LOGOUT_QUERY_PARAM_ALLOWLIST")
+    )
+
+
+def _trusted_spa_hosts(auth_server: str, request: HttpRequest) -> set:
+    """Hosts trusted as the first-party SPA for ``auth_server``.
+
+    The request's own host plus any listed in
+    ``OPENID_CONNECT_AUTH_SERVERS[<server>]["LOGIN_REDIRECT_ALLOWED_HOSTS"]``.
+    One definition of "our SPA", reused by the login-redirect and the
+    account-proxy origin checks so they can't drift.
+
+    The own-host entry is a convenience so same-origin deployments need no
+    extra config. When the Host header isn't one Django will vouch for,
+    ``get_host()`` raises and we simply leave it out: the configured
+    allowlist is the static trust root and stands on its own, so a caller
+    with a forged Host is judged against that alone rather than crashing
+    the check.
+    """
+    allowed_hosts = set(
+        _server_setting_values(auth_server, "LOGIN_REDIRECT_ALLOWED_HOSTS")
+    )
+    try:
+        allowed_hosts.add(request.get_host())
+    except DisallowedHost:
+        logger.warning(
+            "Host header rejected by ALLOWED_HOSTS; judging %r against the "
+            "configured allowlist only.",
             auth_server,
         )
-    )
+    return allowed_hosts
 
 
 def is_safe_login_redirect(
@@ -141,18 +305,30 @@ def is_safe_login_redirect(
     """
     if not url:
         return False
-    config = getattr(settings, "OPENID_CONNECT_AUTH_SERVERS", {})
-    server_config = config.get(auth_server, {})
-    allowed_hosts = set(
-        _coerce_string_iterable(
-            server_config.get("LOGIN_REDIRECT_ALLOWED_HOSTS", ()),
-            "LOGIN_REDIRECT_ALLOWED_HOSTS",
-            auth_server,
-        )
-    )
-    allowed_hosts.add(request.get_host())
     return url_has_allowed_host_and_scheme(
         url,
-        allowed_hosts=allowed_hosts,
+        allowed_hosts=_trusted_spa_hosts(auth_server, request),
+        require_https=request.is_secure(),
+    )
+
+
+def is_allowed_account_origin(auth_server: str, request: HttpRequest) -> bool:
+    """
+    Whether ``request``'s ``Origin`` header is a trusted first-party SPA for
+    account-proxy calls. A missing ``Origin`` is allowed — same-origin
+    requests may omit it, and the custom-header requirement still gates those.
+    """
+    origin = request.headers.get("Origin")
+    if not origin:
+        return True
+
+    # Require an explicit scheme + host.
+    parsed = urlparse(origin)
+    if not parsed.scheme or not parsed.netloc:
+        return False
+
+    return url_has_allowed_host_and_scheme(
+        origin,
+        allowed_hosts=_trusted_spa_hosts(auth_server, request),
         require_https=request.is_secure(),
     )

--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -79,23 +79,13 @@ ID_TOKEN_SESSION_KEY = "oidc_id_token"
 def token_session_key(base_key: str, auth_server: Optional[str]) -> str:
     """Session key for ``base_key``, namespaced to the issuing ``auth_server``.
 
-    ``OPENID_CONNECT_AUTH_SERVERS`` is a keyed dict and every key gets its own
-    routes, so the URL picks the provider while the session holds the tokens.
-    Stored under one global name, those tokens are readable from *every*
-    provider's route: a request to provider B replays provider A's access
-    token against B's account endpoint, and — because B answers a foreign
-    token with 401, which the retry path reads as "expired" — goes on to POST
-    A's long-lived refresh token to B's token endpoint. The same applies to
-    the id_token, which logout replays as ``id_token_hint``.
+    The URL selects the provider while the session holds the tokens, so a
+    global key would let a request to provider B spend provider A's tokens
+    against B's endpoints. Namespacing makes that unrepresentable: B's slot
+    is simply empty, which callers already treat as "no session".
 
-    Namespacing makes that structurally impossible rather than merely
-    checked: B's slot is empty, which every caller already treats as "no
-    session". A guard would work too, but only for as long as each new call
-    site remembers it.
-
-    Deliberately no fallback to the un-namespaced key — reading it would
-    reinstate the very path this closes. Sessions predating this take one
-    401 and sign in again, the same fallback legacy sessions already hit.
+    No fallback to the un-namespaced key — reading it would reinstate the
+    path this closes. Older sessions take one 401 and sign in again.
     """
     return f"{base_key}:{auth_server}"
 
@@ -112,20 +102,10 @@ TOKEN_SESSION_BASE_KEYS = (
 def pending_token_session_key(base_key: str, auth_server: Optional[str]) -> str:
     """Session key for a token parked across the username-form round trip.
 
-    This exists for exactly one flow. When the IdP's claims carry no usable
-    username, ``callback`` answers with an entry form and the browser
-    re-POSTs it carrying only the ``id_token`` — so the access/refresh pair
-    the first request obtained from the token endpoint has to survive in the
-    session until the resubmit, where it is finally earned.
-
-    Nothing else uses pending slots: every other path writes the active
-    slots directly on the success exit. That is deliberate. Writing pending
-    on *every* callback and clearing it on the refusal exits would mean a
-    cleanup call each future exit has to remember, and a forgotten one
-    leaves a live refresh token at rest in the session store belonging to a
-    caller the deployment refused — who, never having signed in, will never
-    log out to clear it. Writing it only where it is needed removes the
-    obligation instead of distributing it.
+    Used by that flow alone: the form re-POSTs only the ``id_token``, so the
+    pair the first request obtained has to survive until the resubmit. Every
+    other path writes the active slots directly on success, which is what
+    keeps a refused caller from leaving a refresh token at rest.
     """
     return f"{token_session_key(base_key, auth_server)}:pending"
 
@@ -139,15 +119,10 @@ def stash_pending_tokens(
 ) -> None:
     """Park a token pair for the username-form round trip.
 
-    ``id_token`` is stored alongside as the pair's owner — see
-    ``take_pending_tokens`` for why that matters.
-
-    All three slots are written as a unit, clearing rather than skipping an
-    absent value. Skipping would break the owner tag's whole guarantee: a
-    second flow whose token response carries no refresh token would
-    overwrite the id and access slots while *inheriting* the first flow's
-    refresh token, and the tag — now naming the second flow — would wave
-    the mismatched pair straight through.
+    ``id_token`` is stored alongside as the pair's owner; see
+    ``take_pending_tokens``. All three slots are written as a unit, clearing
+    rather than skipping an absent value — otherwise a flow with no refresh
+    token would inherit the previous flow's under its own owner tag.
     """
     if session is None or not access_token:
         return
@@ -166,22 +141,12 @@ def stash_pending_tokens(
 def take_pending_tokens(session, auth_server: Optional[str], id_token: Optional[str]):
     """Pop the parked pair, but only if it belongs to ``id_token``.
 
-    Pending slots are keyed per provider, while a single Django session can
-    be running two logins at once — two tabs, same cookie. Both write the
-    same slots, so the pair sitting there when a form is submitted is not
-    necessarily the one that flow started with.
-
-    Handing back a mismatched pair would sign the browser in as one identity
-    while the account proxy authenticated to Keycloak as another: the SPA
-    would show identity X, and ``sessions_list`` / ``credentials_list`` /
-    ``sessions_revoke_one`` would all operate on identity Y's Keycloak
-    account. So a mismatch is dropped rather than used — the login still
-    completes, and the proxy answers 401 until the next full sign-in.
-
-    Always drains all three slots, match or not: a pair that has been
-    refused once must not sit there to be offered to the next login. That
-    also makes the success exit self-cleaning for a login abandoned at the
-    form, whose pair nothing else would ever remove.
+    One session can be running two logins at once (two tabs), and both write
+    the same per-provider slots. Pairing one login's id_token with another's
+    tokens would sign the browser in as one identity while the proxy acted
+    on the other's Keycloak account, so a mismatch is dropped rather than
+    used. Drains all three slots either way, which also clears the pair left
+    by a login abandoned at the form.
 
     Returns ``(access_token, refresh_token)``, either of which may be None.
     """

--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -46,8 +46,15 @@ def authenticate_sso(request, unique_user_field: str = "email"):
 
 
 def str_to_bool(val):
+    """Coerce a settings value that may have come from the environment.
+
+    Only the exact literal ``"False"`` was falsy, so ``"false"`` -- what
+    ``os.getenv("X", "false")`` yields -- read as True. Several settings
+    fail open that way: ``AUTO_CREATE_USER`` and the admin import switch
+    both turn *on* when spelled off.
+    """
     if isinstance(val, str):
-        val = 0 if val == "False" else 1
+        return val.strip().lower() not in ("false", "0", "", "no", "off")
     return val
 
 

--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -139,29 +139,35 @@ def stash_pending_tokens(
 
 
 def take_pending_tokens(session, auth_server: Optional[str], id_token: Optional[str]):
-    """Pop the parked pair, but only if it belongs to ``id_token``.
+    """Pop the parked pair, but only the one ``id_token`` owns.
 
     One session can be running two logins at once (two tabs), and both write
     the same per-provider slots. Pairing one login's id_token with another's
-    tokens would sign the browser in as one identity while the proxy acted
-    on the other's Keycloak account, so a mismatch is dropped rather than
-    used. Drains all three slots either way, which also clears the pair left
-    by a login abandoned at the form.
+    tokens would sign the browser in as one identity while the proxy acted on
+    the other's Keycloak account -- and simply clearing whatever is parked is
+    no better: the other tab then finishes its login with no pair, leaving a
+    proxy that answers 401 for the rest of that session with nothing to say
+    why. So a pair that belongs to someone else is left exactly where it is.
+
+    The cost is that a login abandoned at the username form stays parked
+    until logout clears it, because nothing can tell an abandoned pair from
+    one whose tab is still sitting on the form.
 
     Returns ``(access_token, refresh_token)``, either of which may be None.
     """
-    if session is None:
+    if session is None or not id_token:
         return None, None
-    owner = session.pop(
-        pending_token_session_key(ID_TOKEN_SESSION_KEY, auth_server), None
-    )
+    owner_key = pending_token_session_key(ID_TOKEN_SESSION_KEY, auth_server)
+    if session.get(owner_key) != id_token:
+        return None, None
+    session.pop(owner_key, None)
     access_token = session.pop(
         pending_token_session_key(ACCESS_TOKEN_SESSION_KEY, auth_server), None
     )
     refresh_token = session.pop(
         pending_token_session_key(REFRESH_TOKEN_SESSION_KEY, auth_server), None
     )
-    if not owner or owner != id_token or not access_token:
+    if not access_token:
         # A lone refresh token is never usable on its own, and handing one
         # back would write an active refresh with no matching access token.
         return None, None

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -6,7 +6,7 @@ import importlib
 import logging
 import re
 import traceback
-from typing import Any, List, Mapping, Optional, Tuple
+from typing import Any, Callable, List, Mapping, Optional, Tuple
 
 from django.conf import settings
 from django.contrib.auth import get_user_model, login
@@ -306,6 +306,96 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         return client.request_keycloak_account(
             new_access, method, path_suffix, json_body
         )
+
+    def _proxy_or_error(
+        self,
+        request: HttpRequest,
+        auth_server,
+        method: str,
+        path_suffix: str,
+        json_body: Optional[Mapping[str, Any]] = None,
+        transform: Optional[Callable[[Any], Any]] = None,
+    ) -> HttpResponse:
+        """
+        Boilerplate wrapper for read/write proxy actions: resolve client,
+        validate session, dispatch to ``_keycloak_account_request``,
+        return Response. ``transform`` runs on the parsed body before
+        it's returned so per-endpoint normalisation (e.g. flattening
+        session devices) stays close to the action that needs it.
+        """
+        client = self._get_client(auth_server=auth_server)
+        if client is None:
+            return HttpResponseBadRequest(
+                _("Unable to process OpenID connect account request.")
+            )
+        if not client.account_endpoint:
+            return Response(
+                {"error": "Account endpoint not configured."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        session = getattr(request, "session", None)
+        if session is None:
+            return Response(
+                {"error": "No active session."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        try:
+            status_code, body = self._keycloak_account_request(
+                client, session, method, path_suffix, json_body
+            )
+        except Exception as exc:
+            logger.exception(exc)
+            return Response(
+                {"error": "Could not reach the identity provider."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+        if 200 <= status_code < 300:
+            payload = transform(body) if transform else body
+            return Response(payload, status=status_code)
+        return Response(
+            {"error": "Identity provider rejected the request.", "upstream": body},
+            status=status_code,
+        )
+
+    @action(methods=["GET"], detail=False, url_path="sessions")
+    def sessions_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """
+        List the user's active Keycloak sessions. Flattens
+        Keycloak's per-device representation into one row per
+        session so the SPA renders a flat list.
+        """
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            "/sessions/devices",
+            transform=self._flatten_session_devices,
+        )
+
+    @staticmethod
+    def _flatten_session_devices(body: Optional[list]) -> list:
+        """``[{browser, os, sessions:[{id, started, ...}, ...]}, ...]``
+        → ``[{id, browser, os, started, ...}, ...]``."""
+        if not body:
+            return []
+        rows: list = []
+        for device in body:
+            browser = device.get("browser")
+            os_name = device.get("os")
+            for sess in device.get("sessions", []) or []:
+                rows.append(
+                    {
+                        "id": sess.get("id"),
+                        "browser": browser,
+                        "os": os_name,
+                        "ipAddress": sess.get("ipAddress"),
+                        "started": sess.get("started"),
+                        "lastAccess": sess.get("lastAccess"),
+                        "current": bool(sess.get("current")),
+                        "clients": sess.get("clients", []),
+                    }
+                )
+        return rows
 
     @action(methods=["POST"], detail=False)
     def account(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -491,13 +491,79 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
 
     @action(methods=["GET"], detail=False, url_path="credentials")
     def credentials_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
-        """List credential metadata (TOTP / password / recovery codes)."""
+        """List credential metadata (TOTP / password / recovery codes).
+
+        Keycloak's Account REST returns each credential category with the
+        configured instances nested under ``userCredentialMetadatas`` →
+        ``credential``. SPAs would have to walk two levels just to ask
+        "does the user have a TOTP?" — so we flatten to a single
+        ``credentials`` array of ``{id, userLabel?, createdDate?}`` and
+        forward only the top-level fields the SPA actually renders.
+        """
         return self._proxy_or_error(
             request,
             kwargs.get("auth_server"),
             "GET",
             "/credentials",
+            transform=self._flatten_credentials,
         )
+
+    @staticmethod
+    def _flatten_credentials(body: Optional[list]) -> list:
+        """Reshape Keycloak's credential-metadata array for the SPA.
+
+        Keycloak Account REST shape::
+
+            [
+              {
+                "type": "otp",
+                "category": "two-factor",
+                "displayName": "otp-display-name",
+                "userCredentialMetadatas": [
+                  {"credential": {"id": "...", "userLabel": "...",
+                                  "createdDate": 1700000000000}, ...}
+                ],
+                ...
+              },
+              ...
+            ]
+
+        SPA shape::
+
+            [{"type", "category", "displayName",
+              "credentials": [{"id", "userLabel", "createdDate"}]}, ...]
+        """
+        if not body:
+            return []
+        out: list = []
+        for entry in body:
+            instances = []
+            for meta in entry.get("userCredentialMetadatas", []) or []:
+                cred = (meta or {}).get("credential") or {}
+                cred_id = cred.get("id")
+                if not cred_id:
+                    # A metadata row without an id is unusable — the SPA
+                    # uses id as the React key and as the DELETE path, so
+                    # silently dropping it is safer than rendering a row
+                    # that can't be acted on.
+                    continue
+                row = {"id": cred_id}
+                user_label = cred.get("userLabel")
+                if user_label:
+                    row["userLabel"] = user_label
+                created = cred.get("createdDate")
+                if created is not None:
+                    row["createdDate"] = created
+                instances.append(row)
+            out.append(
+                {
+                    "type": entry.get("type"),
+                    "category": entry.get("category"),
+                    "displayName": entry.get("displayName"),
+                    "credentials": instances,
+                }
+            )
+        return out
 
     @staticmethod
     def _flatten_session_devices(body: Optional[list]) -> list:

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -372,6 +372,18 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             transform=self._flatten_session_devices,
         )
 
+    @action(methods=["DELETE"], detail=False, url_path="sessions")
+    def sessions_revoke_others(
+        self, request: HttpRequest, **kwargs: dict
+    ) -> HttpResponse:
+        """Revoke every Keycloak session except the current one."""
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "DELETE",
+            "/sessions?current=false",
+        )
+
     @staticmethod
     def _flatten_session_devices(body: Optional[list]) -> list:
         """``[{browser, os, sessions:[{id, started, ...}, ...]}, ...]``

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -6,7 +6,7 @@ import importlib
 import logging
 import re
 import traceback
-from typing import List, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Tuple
 
 from django.conf import settings
 from django.contrib.auth import get_user_model, login
@@ -258,6 +258,55 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
     # attributes (Account API rejects them, but be explicit).
     _ACCOUNT_UPDATE_ALLOWED_FIELDS = frozenset({"email", "firstName", "lastName"})
 
+    def _keycloak_account_request(
+        self,
+        client: OpenIDClient,
+        session,
+        method: str,
+        path_suffix: str,
+        json_body: Optional[Mapping[str, Any]] = None,
+    ) -> Tuple[int, Optional[dict]]:
+        """
+        Call Keycloak's Account REST API on behalf of the user identified
+        by the stashed ``oidc_access_token``. On 401 the helper mints a
+        fresh access_token via the stashed ``oidc_refresh_token``, writes
+        the new pair back to the session, and retries once.
+
+        Returns ``(upstream_status, parsed_json_or_None)``. Network
+        failures bubble up as ``RequestException`` — the caller is
+        expected to translate them to 502.
+        """
+        access_token = session.get("oidc_access_token")
+        if not access_token:
+            return 401, {"error": "No active OIDC session."}
+
+        status_code, body = client.request_keycloak_account(
+            access_token, method, path_suffix, json_body
+        )
+        if status_code != 401:
+            return status_code, body
+
+        refresh_token = session.get("oidc_refresh_token")
+        if not refresh_token:
+            return 401, body
+
+        try:
+            tokens = client.refresh_access_token(refresh_token)
+        except TokenVerificationFailed:
+            return 401, {"error": "Session expired — please sign in again."}
+
+        new_access = tokens.get("access_token")
+        new_refresh = tokens.get("refresh_token")
+        if new_access:
+            session["oidc_access_token"] = new_access
+        if new_refresh:
+            session["oidc_refresh_token"] = new_refresh
+        if not new_access:
+            return 401, body
+        return client.request_keycloak_account(
+            new_access, method, path_suffix, json_body
+        )
+
     @action(methods=["POST"], detail=False)
     def account(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         """
@@ -320,8 +369,8 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             )
 
         try:
-            upstream_status, upstream_body = client.update_account_profile(
-                access_token, payload
+            status_code, body = self._keycloak_account_request(
+                client, session, "POST", "", json_body=payload
             )
         except Exception as exc:
             logger.exception(exc)
@@ -330,51 +379,15 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                 status=status.HTTP_502_BAD_GATEWAY,
             )
 
-        # Keycloak returned 401 → the access_token has expired. If we
-        # have a refresh_token, mint a fresh pair and retry once. This
-        # is the only retry path — a second 401 means the refresh
-        # itself is bad and the user has to re-authenticate.
-        if upstream_status == 401:
-            refresh_token = session.get("oidc_refresh_token")
-            if refresh_token:
-                try:
-                    tokens = client.refresh_access_token(refresh_token)
-                except TokenVerificationFailed:
-                    return Response(
-                        {
-                            "error": (
-                                "Session expired — please sign in again."
-                            )
-                        },
-                        status=status.HTTP_401_UNAUTHORIZED,
-                    )
-                new_access = tokens.get("access_token")
-                new_refresh = tokens.get("refresh_token")
-                if new_access:
-                    session["oidc_access_token"] = new_access
-                if new_refresh:
-                    session["oidc_refresh_token"] = new_refresh
-                if new_access:
-                    try:
-                        upstream_status, upstream_body = (
-                            client.update_account_profile(new_access, payload)
-                        )
-                    except Exception as exc:
-                        logger.exception(exc)
-                        return Response(
-                            {"error": "Could not reach the identity provider."},
-                            status=status.HTTP_502_BAD_GATEWAY,
-                        )
-
-        if 200 <= upstream_status < 300:
+        if 200 <= status_code < 300:
             return Response({"success": True}, status=status.HTTP_200_OK)
 
         return Response(
             {
                 "error": "Identity provider rejected the update.",
-                "upstream": upstream_body,
+                "upstream": body,
             },
-            status=upstream_status,
+            status=status_code,
         )
 
     def _username_field_config(self) -> Tuple[str, str]:
@@ -680,9 +693,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                     # Account REST API on behalf of the user (and
                     # refresh on 401 expiry). ``user_tokens`` is the
                     # raw token-endpoint response dict.
-                    if callback_session is not None and isinstance(
-                        user_tokens, dict
-                    ):
+                    if callback_session is not None and isinstance(user_tokens, dict):
                         access_token = user_tokens.get("access_token")
                         refresh_token = user_tokens.get("refresh_token")
                         if access_token:

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -71,6 +71,18 @@ DEFAULT_USERNAME_HELP_TEXT = "Username should not contain . @ - symbols"
 logger = logging.getLogger(__name__)
 
 
+def _sid_from_id_token(id_token: str) -> Optional[str]:
+    """Decode the ``sid`` claim from an id_token *without* verifying the
+    signature. The token was already verified at callback time and
+    stashed in the user's session; we only need the session-id claim
+    to power the revoke-current guard."""
+    try:
+        unverified = jwt.decode(id_token, options={"verify_signature": False})
+    except jwt.exceptions.InvalidTokenError:
+        return None
+    return unverified.get("sid")
+
+
 class BaseOpenIDConnectViewset(viewsets.ViewSet):
     """
     BaseOpenIDConnectViewset: Base viewset that implements login and logout
@@ -370,6 +382,39 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             "GET",
             "/sessions/devices",
             transform=self._flatten_session_devices,
+        )
+
+    @action(
+        methods=["DELETE"],
+        detail=False,
+        url_path=r"sessions/(?P<session_id>[a-zA-Z0-9._-]+)",
+    )
+    def sessions_revoke_one(
+        self, request: HttpRequest, session_id: str = "", **kwargs: dict
+    ) -> HttpResponse:
+        """Revoke one Keycloak session by id. Rejects the user's current
+        session (defence in depth — the SPA already blocks this at the
+        button level)."""
+        session = getattr(request, "session", None)
+        if session is not None:
+            id_token = session.get("oidc_id_token")
+            if id_token:
+                current_sid = _sid_from_id_token(id_token)
+                if current_sid and current_sid == session_id:
+                    return Response(
+                        {
+                            "error": (
+                                "Cannot revoke the current session via this "
+                                "endpoint; use sign-out instead."
+                            )
+                        },
+                        status=status.HTTP_409_CONFLICT,
+                    )
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "DELETE",
+            f"/sessions/{session_id}",
         )
 
     @action(methods=["DELETE"], detail=False, url_path="sessions")

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -71,6 +71,9 @@ DEFAULT_USERNAME_HELP_TEXT = "Username should not contain . @ - symbols"
 logger = logging.getLogger(__name__)
 
 
+_PROVIDER_ALIAS_RE = re.compile(r"^[a-z0-9_-]+$")
+
+
 def _sid_from_id_token(id_token: str) -> Optional[str]:
     """Decode the ``sid`` claim from an id_token *without* verifying the
     signature. The token was already verified at callback time and
@@ -427,6 +430,73 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             kwargs.get("auth_server"),
             "DELETE",
             "/sessions?current=false",
+        )
+
+    @action(methods=["GET"], detail=False, url_path="linked-accounts")
+    def linked_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """List broker IdPs configured on the realm with their connected
+        state for the current user."""
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            "/linked-accounts",
+        )
+
+    @action(
+        methods=["DELETE"],
+        detail=False,
+        url_path=r"linked-accounts/(?P<provider>[^/]+)",
+    )
+    def linked_unlink(
+        self, request: HttpRequest, provider: str = "", **kwargs: dict
+    ) -> HttpResponse:
+        """Unlink a broker IdP from the current user."""
+        if not _PROVIDER_ALIAS_RE.match(provider):
+            return Response(
+                {"error": "Invalid provider alias."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "DELETE",
+            f"/linked-accounts/{provider}",
+        )
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"linked-accounts/(?P<provider>[^/]+)/link-url",
+    )
+    def linked_link_url(
+        self, request: HttpRequest, provider: str = "", **kwargs: dict
+    ) -> HttpResponse:
+        """Get a one-shot URL the SPA opens in a new tab to drive
+        Keycloak's broker-link flow for ``provider``."""
+        if not _PROVIDER_ALIAS_RE.match(provider):
+            return Response(
+                {"error": "Invalid provider alias."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            f"/linked-accounts/{provider}",
+            transform=lambda body: (
+                {"url": body.get("accountLinkUri")} if body else None
+            ),
+        )
+
+    @action(methods=["GET"], detail=False, url_path="credentials")
+    def credentials_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """List credential metadata (TOTP / password / recovery codes)."""
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            "/credentials",
         )
 
     @staticmethod

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -6,6 +6,7 @@ import importlib
 import logging
 import re
 import traceback
+from collections.abc import Mapping
 from typing import List, Optional, Tuple
 
 from django.conf import settings
@@ -72,9 +73,29 @@ SSO_COOKIE_NAME = "SSO"
 USERNAME_FORM_MARKER_FIELD = "from_username_form"
 USERNAME_FORM_MARKER_VALUE = "1"
 
-# Rendering this template is the one callback exit allowed to leave a token
-# pair parked in the session; see ``callback``.
 USERNAME_FORM_TEMPLATE = "oidc/oidc_user_data_entry.html"
+
+# Stamped on the username-form response: it is the one callback exit allowed
+# to leave a token pair parked in the session, and ``callback`` reads this to
+# tell it apart. An attribute rather than the template path, which a
+# deployment is free to repoint at its own form.
+PAIR_PARKED_ATTR = "_oidc_pair_parked"
+
+
+def _claimed_id_token(request) -> Optional[str]:
+    """The id_token this request carries, for scoping the pending drain.
+
+    Read defensively. It happens in ``callback``'s ``finally``, where DRF
+    parses the body lazily: an unparseable or unsupported one raises there
+    and would replace whatever exception is already on its way out, and a
+    JSON body that is not an object has no ``.get`` at all.
+    """
+    try:
+        data = request.data
+    except Exception:  # noqa: BLE001 - any parse failure, and none of them matter here
+        return None
+    return data.get("id_token") if isinstance(data, Mapping) else None
+
 
 # Defaults used when FIELD_VALIDATION_REGEX has no "username" entry.
 # Kept conservative so the rendered form matches the legacy template
@@ -416,11 +437,13 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             "username_help_text": help_text,
             "state": state or "",
         }
-        return Response(
+        response = Response(
             merged,
             template_name=USERNAME_FORM_TEMPLATE,
             **response_kwargs,
         )
+        setattr(response, PAIR_PARKED_ATTR, True)
+        return response
 
     def _check_user_uniqueness(self, user_data: dict) -> Optional[str]:
         """
@@ -682,11 +705,11 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             response = self._callback(request, **kwargs)
             return response
         finally:
-            if getattr(response, "template_name", None) != USERNAME_FORM_TEMPLATE:
+            if not getattr(response, PAIR_PARKED_ATTR, False):
                 take_pending_tokens(
                     getattr(request, "session", None),
                     kwargs.get("auth_server"),
-                    request.data.get("id_token"),
+                    _claimed_id_token(request),
                 )
 
     def _callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -672,15 +672,22 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         Scoped to the id_token this request carries, which is the only pair
         that can be ours: a first callback that fails has parked nothing,
         and clearing the slots wholesale would strand a second tab.
+
+        In a ``finally``: an id_token this library has no handler for raises
+        past every ``except`` below and becomes a 500, which is an exit like
+        any other and must not be the one that gets to keep a pair.
         """
-        response = self._callback(request, **kwargs)
-        if getattr(response, "template_name", None) != USERNAME_FORM_TEMPLATE:
-            take_pending_tokens(
-                getattr(request, "session", None),
-                kwargs.get("auth_server"),
-                request.data.get("id_token"),
-            )
-        return response
+        response = None
+        try:
+            response = self._callback(request, **kwargs)
+            return response
+        finally:
+            if getattr(response, "template_name", None) != USERNAME_FORM_TEMPLATE:
+                take_pending_tokens(
+                    getattr(request, "session", None),
+                    kwargs.get("auth_server"),
+                    request.data.get("id_token"),
+                )
 
     def _callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa
         auth_server = kwargs.get("auth_server")

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -251,6 +251,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         detail=False,
         authentication_classes=[],
         renderer_classes=[JSONRenderer],
+        # ``session/?`` like the other three: the router anchors patterns, so
+        # without it a configured probe URL with a trailing slash 404s.
+        url_path=r"session/?",
         url_name="openid_connect_session",
     )
     def session(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -160,12 +160,8 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             getattr(settings, "SESSION_ENGINE", "")
             == "django.contrib.sessions.backends.signed_cookies"
         ):
-            # Signed-cookie sessions are signed but *not encrypted*: the
-            # contents ride in a client-readable cookie and stay replayable
-            # after logout, because there is no server-side record to delete.
-            # Fine for the id_token this viewset family stashed before, which
-            # the browser already held; not fine for the access and refresh
-            # tokens a proxy-enabled viewset keeps.
+            # Signed but not encrypted: client-readable, and replayable
+            # after logout since there is no server-side record to delete.
             raise ImproperlyConfigured(
                 "The Keycloak account proxy stores access and refresh tokens "
                 "in request.session, which the signed_cookies backend would "
@@ -313,31 +309,19 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             # without middleware. Treat missing session as "no stashed
             # token" — same fallback as the legacy bare end-session URL.
             session = getattr(request, "session", None)
-            # Everything this provider stashed goes, not just the hint. The
-            # response below is a *redirect* the user may never complete —
-            # closed tab, declined confirm screen, unreachable IdP — so this
-            # is the only point in the flow we control. Left behind, the pair
-            # keeps a logged-out session calling the account proxy as the
-            # user, and leaves a refresh token at rest in the session store.
-            #
-            # Scoped to this provider throughout: logging out of A must not
-            # sign the user out of B, and replaying A's id_token to B as
-            # ``id_token_hint`` would disclose sub/email/name to the wrong IdP.
+            # Everything this provider stashed, not just the hint: the
+            # redirect below may never be completed, so this is the only
+            # point we control. Scoped per provider — logging out of A must
+            # not sign the user out of B.
             id_token_hint = None
             if session is not None:
                 for base_key in TOKEN_SESSION_BASE_KEYS:
                     value = session.pop(token_session_key(base_key, auth_server), None)
                     if base_key == ID_TOKEN_SESSION_KEY:
                         id_token_hint = value
-                    # Pending slots too: a login abandoned at the username
-                    # form leaves a pair there, and nothing else clears it.
                     session.pop(pending_token_session_key(base_key, auth_server), None)
-                    # And the pre-namespacing key. This is a *write*-side
-                    # cleanup only -- it does not reinstate the fallback read
-                    # that ``token_session_key`` deliberately refuses, so it
-                    # cannot bring back the cross-provider path. Without it a
-                    # token stashed before the rename outlives every logout,
-                    # since the session is only flushed under USE_AUTH_BACKEND.
+                    # Pre-namespacing key: a write-side sweep only, so it does
+                    # not reinstate the fallback read.
                     session.pop(base_key, None)
             if id_token_hint:
                 extra_params["id_token_hint"] = id_token_hint
@@ -587,42 +571,18 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
     ) -> None:
         """Write the IdP's tokens into the session. Success exit only.
 
-        The id_token is kept so ``logout`` can replay it as
-        ``id_token_hint`` on the end-session URL; without it Keycloak 18+
-        shows the logout-confirm screen even when ``client_id`` and a
-        whitelisted ``post_logout_redirect_uri`` are passed. The
-        access/refresh pair is kept only by viewsets that call the IdP on
-        the user's behalf (``stash_oidc_tokens``).
-
-        Everything is keyed by ``auth_server``: the route selects the
-        provider, so a global key would let another provider's route spend
-        these — see ``token_session_key``.
-
-        ``session`` is attached by ``SessionMiddleware``; absent in callback
-        rigs that build requests via ``APIRequestFactory`` without
-        middleware, so guard the write the way ``logout`` guards the read.
+        The id_token is kept for ``logout``'s ``id_token_hint``; the
+        access/refresh pair only by viewsets that call the IdP on the user's
+        behalf (``stash_oidc_tokens``). Keyed by ``auth_server`` — see
+        ``token_session_key``.
         """
         session = getattr(request, "session", None)
         if session is None:
             return
 
-        # Rotate the session id at the anonymous -> authenticated boundary.
-        # Django's ``login()`` would do this, but it only runs under
-        # USE_AUTH_BACKEND, which is off by default -- so without this the
-        # tokens land in whatever session id the request arrived with. An
-        # attacker who can plant one (subdomain cookie-tossing, or any XSS
-        # on a sibling host under a shared SESSION_COOKIE_DOMAIN) would then
-        # hold a session carrying the victim's access *and* refresh tokens,
-        # and the proxy's refresh loop keeps renewing them. ``cycle_key``
-        # keeps the session data and only changes the key, so the pending
-        # slots read below survive it.
-        #
-        # Skipped under USE_AUTH_BACKEND: Django's ``login()`` has already
-        # run by this point and always cycles or flushes, so rotating again
-        # would only cost a second round trip to the session store.
-        #
-        # Guarded on hasattr: the dict rigs used by callback tests have no
-        # cycle_key. Every real backend does.
+        # Session fixation: rotate before storing credentials. Skipped under
+        # USE_AUTH_BACKEND, where Django's ``login()`` has already cycled.
+        # ``cycle_key`` keeps the data, so the pending slots below survive.
         if not self.use_auth_backend and hasattr(session, "cycle_key"):
             session.cycle_key()
 
@@ -763,15 +723,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                 try:
                     id_token = id_token or user_tokens.get("id_token")
                     decoded_id_token = client.verify_and_decode_id_token(id_token)
-                    # Nothing is written to the session here. The IdP
-                    # vouching for this user is not the platform accepting
-                    # them, and several refusal exits still lie below —
-                    # tokens written now would leave every one of them
-                    # looking like a signed-in session to the account proxy,
-                    # and would leave a refused caller's refresh token at
-                    # rest with nothing that will ever clear it. The success
-                    # exit calls ``_persist_oidc_tokens``; the username-form
-                    # exits park the pair via ``stash_pending_tokens``.
+                    # Nothing is stored yet: refusal exits still lie below,
+                    # and a refused caller must not end up with a session the
+                    # proxy treats as signed in. The success exit persists.
                     user_claims = client.tokens_to_user_info(
                         self.map_claims_to_model_field(decoded_id_token),
                         id_token,
@@ -861,12 +815,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                                     "id_token": id_token,
                                     "error": f"{field.capitalize()} field is already in use.",
                                 }
-                                # Log the conflicting field, never ``data``:
-                                # it carries the raw id_token, and callback
-                                # accepts an id_token straight from the POST
-                                # body on the username-form path. Anyone who
-                                # can read the logs could replay it and sign
-                                # in as that user.
+                                # The field, never ``data`` -- it carries the
+                                # id_token, which callback accepts from the
+                                # POST body and is therefore replayable.
                                 logger.info("Field already in use: %r", field)
                                 return self._username_form_response(
                                     data,
@@ -929,14 +880,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                             redirect_after=redirect_after,
                             auth_server=auth_server,
                         )
-                        # After, not before: under USE_AUTH_BACKEND the call
-                        # above runs Django's ``login()``, which *flushes*
-                        # the session when a different user was already
-                        # authenticated in it. Tokens written first would be
-                        # silently discarded, leaving a browser that is
-                        # signed in but whose every proxy call 401s. The
-                        # session is saved by SessionMiddleware after the
-                        # view returns, so writing here still persists.
+                        # After, not before: the call above runs Django's
+                        # ``login()``, which flushes the session when a
+                        # different user was authenticated in it.
                         self._persist_oidc_tokens(
                             request, auth_server, id_token, user_tokens
                         )

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -41,14 +41,22 @@ from oidc.client import (
     state_cache_key,
 )
 from oidc.utils import (
+    ACCESS_TOKEN_SESSION_KEY,
+    ID_TOKEN_SESSION_KEY,
+    REFRESH_TOKEN_SESSION_KEY,
+    TOKEN_SESSION_BASE_KEYS,
     authenticate_sso,
     email_usename_to_url_safe,
     get_login_query_param_allowlist,
     get_logout_query_param_allowlist,
     get_viewset_config,
     is_safe_login_redirect,
+    pending_token_session_key,
     replace_characters_in_username,
+    stash_pending_tokens,
     str_to_bool,
+    take_pending_tokens,
+    token_session_key,
 )
 
 default_config = getattr(default, "OPENID_CONNECT_VIEWSET_CONFIG", {})
@@ -82,6 +90,13 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
     permission_classes = [permissions.AllowAny]
     renderer_classes = [JSONRenderer, TemplateHTMLRenderer]
     user_model = None
+
+    #: Whether ``callback`` keeps the access/refresh pair in the session.
+    #: Off by default: only a subclass that later calls the IdP on the
+    #: user's behalf needs them, and a stashed refresh token is long-lived
+    #: credential material at rest in the session store. Subclasses that
+    #: need it turn it on -- see ``oidc.keycloak.KeycloakAccountMixin``.
+    stash_oidc_tokens = False
 
     def perform_authentication(self, request):
         if getattr(self, "action", None) == "session":
@@ -141,6 +156,22 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                 "SSO_COOKIE_SAMESITE='None' requires Secure=True; "
                 "set SSO_COOKIE_SECURE=True or SESSION_COOKIE_SECURE=True."
             )
+        if self.stash_oidc_tokens and (
+            getattr(settings, "SESSION_ENGINE", "")
+            == "django.contrib.sessions.backends.signed_cookies"
+        ):
+            # Signed-cookie sessions are signed but *not encrypted*: the
+            # contents ride in a client-readable cookie and stay replayable
+            # after logout, because there is no server-side record to delete.
+            # Fine for the id_token this viewset family stashed before, which
+            # the browser already held; not fine for the access and refresh
+            # tokens a proxy-enabled viewset keeps.
+            raise ImproperlyConfigured(
+                "The Keycloak account proxy stores access and refresh tokens "
+                "in request.session, which the signed_cookies backend would "
+                "expose to the client and leave replayable after logout. Use "
+                "a server-side SESSION_ENGINE (db, cache, cached_db, file)."
+            )
         self.use_auth_backend = str_to_bool(config.get("USE_AUTH_BACKEND", False))
         self.auth_backend = config.get(
             "AUTH_BACKEND", "django.contrib.auth.backends.ModelBackend"
@@ -174,7 +205,12 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             return bool(self.cookie_secure)
         return bool(getattr(settings, "SESSION_COOKIE_SECURE", False))
 
-    @action(methods=["GET"], detail=False)
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"login/?",
+        url_name="openid_connect_login",
+    )
     def login(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)
@@ -219,6 +255,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         detail=False,
         authentication_classes=[],
         renderer_classes=[JSONRenderer],
+        url_name="openid_connect_session",
     )
     def session(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         """Return the current SSO-backed browser session, without tokens.
@@ -255,23 +292,53 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         """Return the non-secret session payload for ``user``."""
         return {"username": user.username}
 
-    @action(methods=["GET"], detail=False)
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"logout/?",
+        url_name="openid_connect_logout",
+    )
     def logout(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)
         if client:
-            # Pop (not get) so the token doesn't outlive the session
-            # it belonged to. If absent (legacy session predating the
-            # callback storing it), the end-session URL falls back to
-            # the bare ``client_id`` + ``post_logout_redirect_uri``
-            # baked into ``END_SESSION_ENDPOINT``.
+            # Pop (not get) so the tokens don't outlive the session they
+            # belonged to. If absent (legacy session predating the callback
+            # storing them), the end-session URL falls back to the bare
+            # ``client_id`` + ``post_logout_redirect_uri`` baked into
+            # ``END_SESSION_ENDPOINT``.
             extra_params: dict[str, str] = {}
             # ``session`` is attached by ``SessionMiddleware``; absent in
             # test rigs that build requests via ``APIRequestFactory``
             # without middleware. Treat missing session as "no stashed
             # token" — same fallback as the legacy bare end-session URL.
             session = getattr(request, "session", None)
-            id_token_hint = session.pop("oidc_id_token", None) if session else None
+            # Everything this provider stashed goes, not just the hint. The
+            # response below is a *redirect* the user may never complete —
+            # closed tab, declined confirm screen, unreachable IdP — so this
+            # is the only point in the flow we control. Left behind, the pair
+            # keeps a logged-out session calling the account proxy as the
+            # user, and leaves a refresh token at rest in the session store.
+            #
+            # Scoped to this provider throughout: logging out of A must not
+            # sign the user out of B, and replaying A's id_token to B as
+            # ``id_token_hint`` would disclose sub/email/name to the wrong IdP.
+            id_token_hint = None
+            if session is not None:
+                for base_key in TOKEN_SESSION_BASE_KEYS:
+                    value = session.pop(token_session_key(base_key, auth_server), None)
+                    if base_key == ID_TOKEN_SESSION_KEY:
+                        id_token_hint = value
+                    # Pending slots too: a login abandoned at the username
+                    # form leaves a pair there, and nothing else clears it.
+                    session.pop(pending_token_session_key(base_key, auth_server), None)
+                    # And the pre-namespacing key. This is a *write*-side
+                    # cleanup only -- it does not reinstate the fallback read
+                    # that ``token_session_key`` deliberately refuses, so it
+                    # cannot bring back the cross-provider path. Without it a
+                    # token stashed before the rename outlives every logout,
+                    # since the session is only flushed under USE_AUTH_BACKEND.
+                    session.pop(base_key, None)
             if id_token_hint:
                 extra_params["id_token_hint"] = id_token_hint
 
@@ -319,6 +386,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         data: dict,
         *,
         state: Optional[str] = None,
+        request: Optional[HttpRequest] = None,
+        auth_server: Optional[str] = None,
+        user_tokens=None,
         **response_kwargs,
     ) -> Response:
         """
@@ -330,7 +400,24 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         state once via the kwarg; the helper guarantees it's emitted on
         every render so `_clear_login_states` can drop the PKCE cache
         entry on the success path that follows.
+
+        This is also the one place that parks the access/refresh pair for
+        the round trip: the form re-POSTs only the id_token, so a pair kept
+        in locals would be lost. Parking here rather than at each caller
+        means the three form exits cannot disagree, and a future one that
+        forgets to pass ``user_tokens`` fails closed — the user completes
+        login without a pair and the account proxy answers 401, rather than
+        a credential being left somewhere it should not be.
         """
+        if request is not None and self.stash_oidc_tokens:
+            tokens = user_tokens if isinstance(user_tokens, dict) else {}
+            stash_pending_tokens(
+                getattr(request, "session", None),
+                auth_server,
+                data.get("id_token"),
+                tokens.get("access_token"),
+                tokens.get("refresh_token"),
+            )
         regex, help_text = self._username_field_config()
         merged = {
             **data,
@@ -434,7 +521,10 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                 field_validation_regex = self.field_validation_regex[k]
                 regex = re.compile(field_validation_regex.get("regex"))
                 if regex and not regex.search(data[k]):
-                    logger.info(f"Invalid `{k}` value `{data[k]}`")
+                    # %r, not an f-string: the value is caller-supplied, and
+                    # interpolating it raw lets a newline forge extra log
+                    # lines. Matches the style used at the ?next= rejection.
+                    logger.info("Invalid %r value %r", k, data[k])
                     raise ValueError(
                         field_validation_regex.get("help_text")
                         or f"Invalid `{k}` value `{data[k]}`"
@@ -488,6 +578,84 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
 
         return user_data, missing_fields
 
+    def _persist_oidc_tokens(
+        self,
+        request: HttpRequest,
+        auth_server: Optional[str],
+        id_token: Optional[str],
+        user_tokens,
+    ) -> None:
+        """Write the IdP's tokens into the session. Success exit only.
+
+        The id_token is kept so ``logout`` can replay it as
+        ``id_token_hint`` on the end-session URL; without it Keycloak 18+
+        shows the logout-confirm screen even when ``client_id`` and a
+        whitelisted ``post_logout_redirect_uri`` are passed. The
+        access/refresh pair is kept only by viewsets that call the IdP on
+        the user's behalf (``stash_oidc_tokens``).
+
+        Everything is keyed by ``auth_server``: the route selects the
+        provider, so a global key would let another provider's route spend
+        these — see ``token_session_key``.
+
+        ``session`` is attached by ``SessionMiddleware``; absent in callback
+        rigs that build requests via ``APIRequestFactory`` without
+        middleware, so guard the write the way ``logout`` guards the read.
+        """
+        session = getattr(request, "session", None)
+        if session is None:
+            return
+
+        # Rotate the session id at the anonymous -> authenticated boundary.
+        # Django's ``login()`` would do this, but it only runs under
+        # USE_AUTH_BACKEND, which is off by default -- so without this the
+        # tokens land in whatever session id the request arrived with. An
+        # attacker who can plant one (subdomain cookie-tossing, or any XSS
+        # on a sibling host under a shared SESSION_COOKIE_DOMAIN) would then
+        # hold a session carrying the victim's access *and* refresh tokens,
+        # and the proxy's refresh loop keeps renewing them. ``cycle_key``
+        # keeps the session data and only changes the key, so the pending
+        # slots read below survive it.
+        #
+        # Guarded: the dict rigs used by callback tests have no cycle_key.
+        if hasattr(session, "cycle_key"):
+            session.cycle_key()
+
+        tokens = user_tokens if isinstance(user_tokens, dict) else {}
+        access_token = tokens.get("access_token")
+        refresh_token = tokens.get("refresh_token")
+
+        # Drained unconditionally, even when a pair is already in hand: a
+        # login abandoned at the username form parks a pair that nothing
+        # else would ever remove, so the next success in this session is the
+        # only thing positioned to clear it.
+        parked_access, parked_refresh = take_pending_tokens(
+            session, auth_server, id_token
+        )
+        if not access_token:
+            # Nothing in hand means this is the form resubmit, which carries
+            # only the id_token — the pair came from the first callback, and
+            # is handed back only if it belongs to this id_token.
+            access_token, refresh_token = parked_access, parked_refresh
+
+        if id_token:
+            session[token_session_key(ID_TOKEN_SESSION_KEY, auth_server)] = id_token
+        if not self.stash_oidc_tokens:
+            return
+        # Written as a unit with the id_token above, clearing rather than
+        # skipping. Skipping would let an earlier login's pair survive beside
+        # this login's id_token — precisely the cross-identity split the
+        # owner tag exists to prevent, arrived at from the other direction.
+        for base_key, value in (
+            (ACCESS_TOKEN_SESSION_KEY, access_token),
+            (REFRESH_TOKEN_SESSION_KEY, refresh_token),
+        ):
+            key = token_session_key(base_key, auth_server)
+            if value:
+                session[key] = value
+            else:
+                session.pop(key, None)
+
     def _clear_login_states(self, server_response: dict) -> None:
         """Clear cached login states
 
@@ -497,7 +665,12 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         if state:
             cache.delete(state_cache_key(state))
 
-    @action(methods=["POST", "GET"], detail=False)
+    @action(
+        methods=["POST", "GET"],
+        detail=False,
+        url_path=r"callback/?",
+        url_name="openid_connect_callback",
+    )
     def callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)
@@ -585,19 +758,15 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                 try:
                     id_token = id_token or user_tokens.get("id_token")
                     decoded_id_token = client.verify_and_decode_id_token(id_token)
-                    # Stash the raw id_token in the Django session so
-                    # the logout action below can replay it as
-                    # `id_token_hint` on the Keycloak end-session URL.
-                    # Without it, Keycloak 18+ shows the logout-confirm
-                    # screen even when `client_id` + a whitelisted
-                    # `post_logout_redirect_uri` are passed.
-                    # ``session`` is attached by ``SessionMiddleware``;
-                    # absent in callback rigs that build requests via
-                    # ``APIRequestFactory`` without middleware, so guard
-                    # the write the same way ``logout`` guards the read.
-                    callback_session = getattr(request, "session", None)
-                    if id_token and callback_session is not None:
-                        callback_session["oidc_id_token"] = id_token
+                    # Nothing is written to the session here. The IdP
+                    # vouching for this user is not the platform accepting
+                    # them, and several refusal exits still lie below —
+                    # tokens written now would leave every one of them
+                    # looking like a signed-in session to the account proxy,
+                    # and would leave a refused caller's refresh token at
+                    # rest with nothing that will ever clear it. The success
+                    # exit calls ``_persist_oidc_tokens``; the username-form
+                    # exits park the pair via ``stash_pending_tokens``.
                     user_claims = client.tokens_to_user_info(
                         self.map_claims_to_model_field(decoded_id_token),
                         id_token,
@@ -655,9 +824,17 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                                 and list(missing_fields)[0] == "username"
                             ):
                                 data = {"id_token": id_token}
-                                logger.info("missing_fields: ", missing_fields)
+                                # %-style, not a second positional: passing
+                                # an arg to a format string with no
+                                # placeholder raises inside logging and the
+                                # record is dropped, so this never logged.
+                                logger.info("missing_fields: %r", missing_fields)
                                 return self._username_form_response(
-                                    data, state=server_response.get("state")
+                                    data,
+                                    state=server_response.get("state"),
+                                    request=request,
+                                    auth_server=auth_server,
+                                    user_tokens=user_tokens,
                                 )
                             else:
                                 missing_fields = ", ".join(missing_fields)
@@ -679,9 +856,19 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                                     "id_token": id_token,
                                     "error": f"{field.capitalize()} field is already in use.",
                                 }
-                                logger.info(data)
+                                # Log the conflicting field, never ``data``:
+                                # it carries the raw id_token, and callback
+                                # accepts an id_token straight from the POST
+                                # body on the username-form path. Anyone who
+                                # can read the logs could replay it and sign
+                                # in as that user.
+                                logger.info("Field already in use: %r", field)
                                 return self._username_form_response(
-                                    data, state=server_response.get("state")
+                                    data,
+                                    state=server_response.get("state"),
+                                    request=request,
+                                    auth_server=auth_server,
+                                    user_tokens=user_tokens,
                                 )
 
                         self.validate_fields(user_data)
@@ -699,6 +886,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                     return self._username_form_response(
                         {"error": str(e), "id_token": id_token},
                         state=server_response.get("state"),
+                        request=request,
+                        auth_server=auth_server,
+                        user_tokens=user_tokens,
                         status=status.HTTP_400_BAD_REQUEST,
                     )
                 except jwt.exceptions.DecodeError:
@@ -728,6 +918,10 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                         user.last_login = timezone.now()
                         user.save(update_fields=["last_login"])
                         self._clear_login_states(server_response)
+                        # Login accepted: the tokens are earned.
+                        self._persist_oidc_tokens(
+                            request, auth_server, id_token, user_tokens
+                        )
                         return self.generate_successful_response(
                             request,
                             user,

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -900,6 +900,17 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                             self._persist_oidc_tokens(
                                 request, auth_server, id_token, user_tokens
                             )
+                        else:
+                            # Persisting is also what drains the pending
+                            # slots, so a refusal has to do it explicitly --
+                            # otherwise a login refused at the username form
+                            # leaves its parked pair behind, and a refused
+                            # caller never reaches logout to clear it.
+                            take_pending_tokens(
+                                getattr(request, "session", None),
+                                auth_server,
+                                id_token,
+                            )
                         return response
         auth_servers = list(settings.OPENID_CONNECT_AUTH_SERVERS.keys())
         default_auth_server = auth_servers[0] if auth_servers else "default"

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -617,8 +617,13 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         # keeps the session data and only changes the key, so the pending
         # slots read below survive it.
         #
-        # Guarded: the dict rigs used by callback tests have no cycle_key.
-        if hasattr(session, "cycle_key"):
+        # Skipped under USE_AUTH_BACKEND: Django's ``login()`` has already
+        # run by this point and always cycles or flushes, so rotating again
+        # would only cost a second round trip to the session store.
+        #
+        # Guarded on hasattr: the dict rigs used by callback tests have no
+        # cycle_key. Every real backend does.
+        if not self.use_auth_backend and hasattr(session, "cycle_key"):
             session.cycle_key()
 
         tokens = user_tokens if isinstance(user_tokens, dict) else {}
@@ -918,16 +923,24 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                         user.last_login = timezone.now()
                         user.save(update_fields=["last_login"])
                         self._clear_login_states(server_response)
-                        # Login accepted: the tokens are earned.
-                        self._persist_oidc_tokens(
-                            request, auth_server, id_token, user_tokens
-                        )
-                        return self.generate_successful_response(
+                        response = self.generate_successful_response(
                             request,
                             user,
                             redirect_after=redirect_after,
                             auth_server=auth_server,
                         )
+                        # After, not before: under USE_AUTH_BACKEND the call
+                        # above runs Django's ``login()``, which *flushes*
+                        # the session when a different user was already
+                        # authenticated in it. Tokens written first would be
+                        # silently discarded, leaving a browser that is
+                        # signed in but whose every proxy call 401s. The
+                        # session is saved by SessionMiddleware after the
+                        # view returns, so writing here still persists.
+                        self._persist_oidc_tokens(
+                            request, auth_server, id_token, user_tokens
+                        )
+                        return response
         auth_servers = list(settings.OPENID_CONNECT_AUTH_SERVERS.keys())
         default_auth_server = auth_servers[0] if auth_servers else "default"
         return Response(

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -883,9 +883,20 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                         # After, not before: the call above runs Django's
                         # ``login()``, which flushes the session when a
                         # different user was authenticated in it.
-                        self._persist_oidc_tokens(
-                            request, auth_server, id_token, user_tokens
-                        )
+                        #
+                        # Only on a response that actually signed the user
+                        # in. Overriding ``generate_successful_response`` to
+                        # refuse a login the library accepted is the
+                        # documented extension point, and the tokens are
+                        # what the account proxy reads as proof of a
+                        # session -- so a subclass's refusal has to be as
+                        # final as one of our own.
+                        if status.is_success(
+                            response.status_code
+                        ) or status.is_redirect(response.status_code):
+                            self._persist_oidc_tokens(
+                                request, auth_server, id_token, user_tokens
+                            )
                         return response
         auth_servers = list(settings.OPENID_CONNECT_AUTH_SERVERS.keys())
         default_auth_server = auth_servers[0] if auth_servers else "default"

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -72,6 +72,10 @@ SSO_COOKIE_NAME = "SSO"
 USERNAME_FORM_MARKER_FIELD = "from_username_form"
 USERNAME_FORM_MARKER_VALUE = "1"
 
+# Rendering this template is the one callback exit allowed to leave a token
+# pair parked in the session; see ``callback``.
+USERNAME_FORM_TEMPLATE = "oidc/oidc_user_data_entry.html"
+
 # Defaults used when FIELD_VALIDATION_REGEX has no "username" entry.
 # Kept conservative so the rendered form matches the legacy template
 # behaviour for deployments that haven't customized validation.
@@ -414,7 +418,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         }
         return Response(
             merged,
-            template_name="oidc/oidc_user_data_entry.html",
+            template_name=USERNAME_FORM_TEMPLATE,
             **response_kwargs,
         )
 
@@ -593,10 +597,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         access_token = tokens.get("access_token")
         refresh_token = tokens.get("refresh_token")
 
-        # Drained unconditionally, even when a pair is already in hand: a
-        # login abandoned at the username form parks a pair that nothing
-        # else would ever remove, so the next success in this session is the
-        # only thing positioned to clear it.
+        # Drained even when a pair is already in hand, so this login's own
+        # parked pair cannot outlive it. Scoped to our id_token: a pair
+        # parked by a second tab still at the username form is left alone.
         parked_access, parked_refresh = take_pending_tokens(
             session, auth_server, id_token
         )
@@ -639,7 +642,31 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         url_path=r"callback/?",
         url_name="openid_connect_callback",
     )
-    def callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa
+    def callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """Handle the IdP's redirect back, and the username form's re-POST.
+
+        Wraps the flow so a parked token pair outlives exactly one round
+        trip. ``_username_form_response`` parks one because the form
+        re-POSTs only the id_token; every other way out -- an expired PKCE
+        entry, an id_token that will not decode, AUTO_CREATE_USER off, a
+        subclass refusing the login, success -- has to take it back, or a
+        refresh token stays at rest in the session of someone who never
+        signed in and so never reaches logout to clear it.
+
+        Scoped to the id_token this request carries, which is the only pair
+        that can be ours: a first callback that fails has parked nothing,
+        and clearing the slots wholesale would strand a second tab.
+        """
+        response = self._callback(request, **kwargs)
+        if getattr(response, "template_name", None) != USERNAME_FORM_TEMPLATE:
+            take_pending_tokens(
+                getattr(request, "session", None),
+                kwargs.get("auth_server"),
+                request.data.get("id_token"),
+            )
+        return response
+
+    def _callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)
         user = redirect_after = code_verifier = None
@@ -900,17 +927,8 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                             self._persist_oidc_tokens(
                                 request, auth_server, id_token, user_tokens
                             )
-                        else:
-                            # Persisting is also what drains the pending
-                            # slots, so a refusal has to do it explicitly --
-                            # otherwise a login refused at the username form
-                            # leaves its parked pair behind, and a refused
-                            # caller never reaches logout to clear it.
-                            take_pending_tokens(
-                                getattr(request, "session", None),
-                                auth_server,
-                                id_token,
-                            )
+                        # A refusal stores nothing; ``callback`` takes the
+                        # parked pair back on the way out.
                         return response
         auth_servers = list(settings.OPENID_CONNECT_AUTH_SERVERS.keys())
         default_auth_server = auth_servers[0] if auth_servers else "default"

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -927,13 +927,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                         user.last_login = timezone.now()
                         user.save(update_fields=["last_login"])
                         self._clear_login_states(server_response)
-                        # Before, not after: the call below runs Django's
-                        # ``login()``, which flushes the session when a
-                        # different user was authenticated in it -- taking
-                        # the parked slots with it. A pair the code exchange
-                        # returned is already in locals and survives that;
-                        # this puts the form path's pair in locals too, so
-                        # both paths reach the write below the same way.
+                        # Before the call below, which runs Django's
+                        # ``login()`` -- and that flushes the session when a
+                        # different user was authenticated in it.
                         user_tokens = self._reunite_with_parked_pair(
                             request, auth_server, id_token, user_tokens
                         )
@@ -943,22 +939,19 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                             redirect_after=redirect_after,
                             auth_server=auth_server,
                         )
-                        #
-                        # Only on a response that actually signed the user
-                        # in. Overriding ``generate_successful_response`` to
-                        # refuse a login the library accepted is the
-                        # documented extension point, and the tokens are
-                        # what the account proxy reads as proof of a
-                        # session -- so a subclass's refusal has to be as
-                        # final as one of our own.
+                        # Only on a response that actually signed the user in.
+                        # Overriding ``generate_successful_response`` to refuse
+                        # a login is the documented extension point, and the
+                        # tokens are what the proxy reads as proof of a session
+                        # -- so a subclass's refusal has to be as final as one
+                        # of our own. It stores nothing; ``callback`` takes the
+                        # parked pair back on the way out.
                         if status.is_success(
                             response.status_code
                         ) or status.is_redirect(response.status_code):
                             self._persist_oidc_tokens(
                                 request, auth_server, id_token, user_tokens
                             )
-                        # A refusal stores nothing; ``callback`` takes the
-                        # parked pair back on the way out.
                         return response
         auth_servers = list(settings.OPENID_CONNECT_AUTH_SERVERS.keys())
         default_auth_server = auth_servers[0] if auth_servers else "default"

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -569,6 +569,34 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
 
         return user_data, missing_fields
 
+    @staticmethod
+    def _reunite_with_parked_pair(
+        request: HttpRequest,
+        auth_server: Optional[str],
+        id_token: Optional[str],
+        user_tokens,
+    ):
+        """Move this flow's parked pair out of the session and into hand.
+
+        The username form re-POSTs only the id_token, so on that path the
+        pair is in the session rather than in ``user_tokens``. Taken here --
+        before anything that can flush the session, and unconditionally, so
+        the pair cannot outlive the flow that parked it. Scoped to our
+        id_token: a pair parked by a second tab still sitting on the form
+        belongs to that tab and is left where it is.
+        """
+        tokens = user_tokens if isinstance(user_tokens, dict) else {}
+        parked_access, parked_refresh = take_pending_tokens(
+            getattr(request, "session", None), auth_server, id_token
+        )
+        if tokens.get("access_token") or not parked_access:
+            return tokens
+        return {
+            **tokens,
+            "access_token": parked_access,
+            "refresh_token": parked_refresh,
+        }
+
     def _persist_oidc_tokens(
         self,
         request: HttpRequest,
@@ -596,18 +624,6 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         tokens = user_tokens if isinstance(user_tokens, dict) else {}
         access_token = tokens.get("access_token")
         refresh_token = tokens.get("refresh_token")
-
-        # Drained even when a pair is already in hand, so this login's own
-        # parked pair cannot outlive it. Scoped to our id_token: a pair
-        # parked by a second tab still at the username form is left alone.
-        parked_access, parked_refresh = take_pending_tokens(
-            session, auth_server, id_token
-        )
-        if not access_token:
-            # Nothing in hand means this is the form resubmit, which carries
-            # only the id_token — the pair came from the first callback, and
-            # is handed back only if it belongs to this id_token.
-            access_token, refresh_token = parked_access, parked_refresh
 
         if id_token:
             session[token_session_key(ID_TOKEN_SESSION_KEY, auth_server)] = id_token
@@ -904,15 +920,22 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                         user.last_login = timezone.now()
                         user.save(update_fields=["last_login"])
                         self._clear_login_states(server_response)
+                        # Before, not after: the call below runs Django's
+                        # ``login()``, which flushes the session when a
+                        # different user was authenticated in it -- taking
+                        # the parked slots with it. A pair the code exchange
+                        # returned is already in locals and survives that;
+                        # this puts the form path's pair in locals too, so
+                        # both paths reach the write below the same way.
+                        user_tokens = self._reunite_with_parked_pair(
+                            request, auth_server, id_token, user_tokens
+                        )
                         response = self.generate_successful_response(
                             request,
                             user,
                             redirect_after=redirect_after,
                             auth_server=auth_server,
                         )
-                        # After, not before: the call above runs Django's
-                        # ``login()``, which flushes the session when a
-                        # different user was authenticated in it.
                         #
                         # Only on a response that actually signed the user
                         # in. Overriding ``generate_successful_response`` to

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ setup_requires =
     setuptools_scm
 
 [options.packages.find]
-exclude = tests
+exclude = tests, tests.*
 
 [bdist_wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,8 @@
 name = ona-oidc
 version = 2.10.0
 description = Ona OpenID Connect Client
-long_description = file: README.rst
-long_description_content_type = text/x-rst
+long_description = file: README.md
+long_description_content_type = text/markdown
 url = https://github.com/onaio/ona-oidc
 author = Ona Systems Inc
 author_email = support@ona.io

--- a/tests/keycloak_urls.py
+++ b/tests/keycloak_urls.py
@@ -1,0 +1,16 @@
+"""
+URLconf for a deployment that opts into the Keycloak account proxy.
+
+``oidc.urls`` resolves ``VIEWSET_CLASS`` at import time, so routing tests for
+the mixin need their own URLconf rather than ``override_settings``.
+"""
+
+from oidc.keycloak import KeycloakOpenIDConnectViewset
+from oidc.routers import UnprefixedNameRouter
+
+router = UnprefixedNameRouter(trailing_slash=False)
+router.register(
+    r"oidc/(?P<auth_server>\w+)", KeycloakOpenIDConnectViewset, basename="oidc"
+)
+
+urlpatterns = router.urls

--- a/tests/project_viewsets.py
+++ b/tests/project_viewsets.py
@@ -11,10 +11,21 @@ circular import.
 
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.permissions import BasePermission
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 from oidc.keycloak import KeycloakAccountMixin
+from oidc.permissions import IsCsrfSafeAccountRequest
 from oidc.viewsets import UserModelOpenIDConnectViewset
+
+#: What the shipped account actions declare. Repeated in the fixtures below so
+#: each one differs from the real route in exactly one way.
+GUARDED = {
+    "authentication_classes": [],
+    "permission_classes": [IsCsrfSafeAccountRequest],
+    "renderer_classes": [JSONRenderer],
+}
 
 
 class InjectedViewset(UserModelOpenIDConnectViewset):
@@ -64,6 +75,7 @@ class NarrowedRedeclareViewset(KeycloakAccountMixin, UserModelOpenIDConnectViews
         detail=False,
         url_path="sessions",
         url_name="openid_connect_sessions",
+        **GUARDED,
     )
     def sessions_list(self, request, **kwargs):
         return super().sessions_list(request, **kwargs)
@@ -80,3 +92,91 @@ class RenamedRouteViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
     )
     def login(self, request, **kwargs):
         return super().login(request, **kwargs)
+
+
+class UnguardedRedeclareViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Route-identical, but the decorator omits the view kwargs -- so
+    ``permission_classes`` falls back to the viewset default, ``AllowAny``,
+    and the account proxy loses its CSRF/Origin gate."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="credentials",
+        url_name="openid_connect_credentials",
+    )
+    def credentials_list(self, request, **kwargs):
+        return super().credentials_list(request, **kwargs)
+
+
+class MovedRouteViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Re-declares under a different url_path, so the old URL 404s."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="account/credentials",
+        url_name="openid_connect_credentials",
+        **GUARDED,
+    )
+    def credentials_list(self, request, **kwargs):
+        return super().credentials_list(request, **kwargs)
+
+
+class DetailRedeclareViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Re-declares with ``detail=True``, which inserts a ``pk`` segment the
+    caller never sends and breaks ``reverse()`` for everyone else."""
+
+    @action(
+        methods=["GET"],
+        detail=True,
+        url_path="credentials",
+        url_name="openid_connect_credentials",
+        **GUARDED,
+    )
+    def credentials_list(self, request, **kwargs):
+        return super().credentials_list(request, **kwargs)
+
+
+class OnlyDuringMaintenance(BasePermission):
+    """Stand-in for a deployment's own extra rule."""
+
+    def has_permission(self, request, view):
+        return True
+
+
+class TightenedRedeclareViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Keeps the shipped gate and adds one of its own, which is narrowing --
+    not the widening E002 exists to catch."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="credentials",
+        url_name="openid_connect_credentials",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest, OnlyDuringMaintenance],
+        renderer_classes=[JSONRenderer],
+    )
+    def credentials_list(self, request, **kwargs):
+        return super().credentials_list(request, **kwargs)
+
+
+class RenamedCompanionViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Re-declares both verbs but names the DELETE handler differently. The
+    route is unchanged -- ``mapping`` holds handler names, not verbs -- so
+    this must not be reported."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="sessions",
+        url_name="openid_connect_sessions",
+        **GUARDED,
+    )
+    def sessions_list(self, request, **kwargs):
+        return super().sessions_list(request, **kwargs)
+
+    @sessions_list.mapping.delete
+    def revoke_every_other_session(self, request, **kwargs):
+        return super().sessions_revoke_others(request, **kwargs)

--- a/tests/project_viewsets.py
+++ b/tests/project_viewsets.py
@@ -9,8 +9,11 @@ a subclass module that reached back into ``oidc.urls`` would deadlock on a
 circular import.
 """
 
+from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.response import Response
 
+from oidc.keycloak import KeycloakAccountMixin
 from oidc.viewsets import UserModelOpenIDConnectViewset
 
 
@@ -37,3 +40,15 @@ class RedeclaredOverrideViewset(UserModelOpenIDConnectViewset):
     )
     def login(self, request, **kwargs):
         return super().login(request, **kwargs)
+
+
+class RefusingViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Mirrors onadata's org-account rejection: the login is refused by
+    overriding ``generate_successful_response``, which is the documented
+    extension point for exactly that."""
+
+    def generate_successful_response(self, request, user, *args, **kwargs):
+        return Response(
+            {"error": "Organization accounts cannot sign in via SSO."},
+            status=status.HTTP_403_FORBIDDEN,
+        )

--- a/tests/project_viewsets.py
+++ b/tests/project_viewsets.py
@@ -1,0 +1,16 @@
+"""
+Stand-in for a project-owned viewset subclass.
+
+Mirrors how a consumer actually does this — onadata's
+``OnaOpenIDConnectViewset`` subclasses the concrete viewset to refuse SSO
+login for organization accounts. Kept in its own module, importing only
+``oidc.viewsets``: ``oidc.urls`` resolves ``VIEWSET_CLASS`` at import time, so
+a subclass module that reached back into ``oidc.urls`` would deadlock on a
+circular import.
+"""
+
+from oidc.viewsets import UserModelOpenIDConnectViewset
+
+
+class InjectedViewset(UserModelOpenIDConnectViewset):
+    """Subclass used to prove routing goes to the configured class."""

--- a/tests/project_viewsets.py
+++ b/tests/project_viewsets.py
@@ -9,8 +9,31 @@ a subclass module that reached back into ``oidc.urls`` would deadlock on a
 circular import.
 """
 
+from rest_framework.decorators import action
+
 from oidc.viewsets import UserModelOpenIDConnectViewset
 
 
 class InjectedViewset(UserModelOpenIDConnectViewset):
     """Subclass used to prove routing goes to the configured class."""
+
+
+class PlainOverrideViewset(UserModelOpenIDConnectViewset):
+    """Overrides an action the way a consumer naturally would -- and thereby
+    loses its route. Exists so the deploy check has something to catch."""
+
+    def login(self, request, **kwargs):
+        return super().login(request, **kwargs)
+
+
+class RedeclaredOverrideViewset(UserModelOpenIDConnectViewset):
+    """The documented fix: re-apply the decorator on the override."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"login/?",
+        url_name="openid_connect_login",
+    )
+    def login(self, request, **kwargs):
+        return super().login(request, **kwargs)

--- a/tests/project_viewsets.py
+++ b/tests/project_viewsets.py
@@ -183,3 +183,82 @@ class RenamedCompanionViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewse
     @sessions_list.mapping.delete
     def revoke_every_other_session(self, request, **kwargs):
         return super().sessions_revoke_others(request, **kwargs)
+
+
+class ReskinnedFormViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Renders the username form from its own template. The pair is still
+    parked by the base method, so this exit must stay exempt from the drain
+    -- keying that on the template path would strand this deployment on the
+    second attempt at a username."""
+
+    def _username_form_response(self, *args, **kwargs):
+        response = super()._username_form_response(*args, **kwargs)
+        response.template_name = "oidc/my_own_user_form.html"
+        return response
+
+
+class UnguardedAuthClassesViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Keeps the permission and renderer kwargs, drops only
+    ``authentication_classes=[]`` -- so DRF's SessionAuthentication comes
+    back and enforces its own CSRF check on a route whose callers have no
+    CSRF token."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=CREDENTIALS_PATH,
+        url_name="openid_connect_credentials",
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
+    def credentials_list(self, request, **kwargs):
+        return super().credentials_list(request, **kwargs)
+
+
+class ComposedPermissionViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Tightens by composing rather than by appending. ``A & B`` collapses
+    into one OperandHolder, so the shipped class is no longer literally in
+    the list."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=CREDENTIALS_PATH,
+        url_name="openid_connect_credentials",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest & OnlyDuringMaintenance],
+        renderer_classes=[JSONRenderer],
+    )
+    def credentials_list(self, request, **kwargs):
+        return super().credentials_list(request, **kwargs)
+
+
+class WidenedPermissionViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """``A | B`` reads like the composed case but is a weakening: the route
+    now passes for anything B admits."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=CREDENTIALS_PATH,
+        url_name="openid_connect_credentials",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest | OnlyDuringMaintenance],
+        renderer_classes=[JSONRenderer],
+    )
+    def credentials_list(self, request, **kwargs):
+        return super().credentials_list(request, **kwargs)
+
+
+class ExtraVerbViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Adds a verb to a route it otherwise re-declares faithfully."""
+
+    @action(
+        methods=["GET", "HEAD"],
+        detail=False,
+        url_path=CREDENTIALS_PATH,
+        url_name="openid_connect_credentials",
+        **GUARDED,
+    )
+    def credentials_list(self, request, **kwargs):
+        return super().credentials_list(request, **kwargs)

--- a/tests/project_viewsets.py
+++ b/tests/project_viewsets.py
@@ -52,3 +52,31 @@ class RefusingViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
             {"error": "Organization accounts cannot sign in via SSO."},
             status=status.HTTP_403_FORBIDDEN,
         )
+
+
+class NarrowedRedeclareViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Follows E002's old hint literally: re-declares the decorator but not
+    the ``@sessions_list.mapping.delete`` companion, so a fresh MethodMapper
+    silently drops DELETE /sessions."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="sessions",
+        url_name="openid_connect_sessions",
+    )
+    def sessions_list(self, request, **kwargs):
+        return super().sessions_list(request, **kwargs)
+
+
+class RenamedRouteViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+    """Re-declares with a different url_name, breaking reverse()."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"login/?",
+        url_name="something_else",
+    )
+    def login(self, request, **kwargs):
+        return super().login(request, **kwargs)

--- a/tests/project_viewsets.py
+++ b/tests/project_viewsets.py
@@ -19,13 +19,16 @@ from oidc.keycloak import KeycloakAccountMixin
 from oidc.permissions import IsCsrfSafeAccountRequest
 from oidc.viewsets import UserModelOpenIDConnectViewset
 
-#: What the shipped account actions declare. Repeated in the fixtures below so
-#: each one differs from the real route in exactly one way.
+#: What the shipped account actions declare. Read off the mixin rather than
+#: repeated, so a fixture below cannot start differing in a second way -- each
+#: is meant to differ from the real route in exactly one.
 GUARDED = {
     "authentication_classes": [],
     "permission_classes": [IsCsrfSafeAccountRequest],
     "renderer_classes": [JSONRenderer],
 }
+SESSIONS_PATH = KeycloakAccountMixin.sessions_list.url_path
+CREDENTIALS_PATH = KeycloakAccountMixin.credentials_list.url_path
 
 
 class InjectedViewset(UserModelOpenIDConnectViewset):
@@ -73,7 +76,7 @@ class NarrowedRedeclareViewset(KeycloakAccountMixin, UserModelOpenIDConnectViews
     @action(
         methods=["GET"],
         detail=False,
-        url_path="sessions",
+        url_path=SESSIONS_PATH,
         url_name="openid_connect_sessions",
         **GUARDED,
     )
@@ -102,7 +105,7 @@ class UnguardedRedeclareViewset(KeycloakAccountMixin, UserModelOpenIDConnectView
     @action(
         methods=["GET"],
         detail=False,
-        url_path="credentials",
+        url_path=CREDENTIALS_PATH,
         url_name="openid_connect_credentials",
     )
     def credentials_list(self, request, **kwargs):
@@ -130,7 +133,7 @@ class DetailRedeclareViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewset
     @action(
         methods=["GET"],
         detail=True,
-        url_path="credentials",
+        url_path=CREDENTIALS_PATH,
         url_name="openid_connect_credentials",
         **GUARDED,
     )
@@ -152,7 +155,7 @@ class TightenedRedeclareViewset(KeycloakAccountMixin, UserModelOpenIDConnectView
     @action(
         methods=["GET"],
         detail=False,
-        url_path="credentials",
+        url_path=CREDENTIALS_PATH,
         url_name="openid_connect_credentials",
         authentication_classes=[],
         permission_classes=[IsCsrfSafeAccountRequest, OnlyDuringMaintenance],
@@ -170,7 +173,7 @@ class RenamedCompanionViewset(KeycloakAccountMixin, UserModelOpenIDConnectViewse
     @action(
         methods=["GET"],
         detail=False,
-        url_path="sessions",
+        url_path=SESSIONS_PATH,
         url_name="openid_connect_sessions",
         **GUARDED,
     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -570,6 +570,7 @@ class OpenIDClientTestCase(TestCase):
             },
             params=None,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=(5, 15),
         )
 
     @override_settings(
@@ -616,6 +617,7 @@ class OpenIDClientTestCase(TestCase):
                 "code_verifier": "123",
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=(5, 15),
         )
 
     @override_settings(
@@ -648,6 +650,7 @@ class OpenIDClientTestCase(TestCase):
         mock_requests_get.assert_called_once_with(
             "https://example.com/oauth2/userinfo",
             headers={"Authorization": "Bearer access_token_value"},
+            timeout=(5, 15),
         )
 
     @override_settings(OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -4,7 +4,8 @@ Test that oidc urls resolve.
 """
 
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.template.loader import get_template
+from django.test import TestCase, override_settings
 from django.urls import resolve, reverse
 
 from rest_framework.renderers import JSONRenderer
@@ -78,3 +79,29 @@ class TestUnprefixedNameRouterScope(TestCase):
         names = self._names(ThingViewSet)
         self.assertIn("thing-list", names)
         self.assertIn("thing-detail", names)
+
+
+class TestShippedTemplatesRenderStandalone(TestCase):
+    """The package renders two pages in a browser, and both extend
+    ``base.html``. The suite puts a fixture one on ``DIRS``, so nothing here
+    exercised what a project that installed the package and followed the
+    README actually gets -- which was TemplateDoesNotExist, i.e. a bare 500
+    on the username form and on every unrecoverable-error page."""
+
+    @override_settings(
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [],
+                "APP_DIRS": True,
+                "OPTIONS": {"context_processors": []},
+            }
+        ]
+    )
+    def test_they_render_with_app_dirs_alone(self):
+        for name in (
+            "oidc/oidc_unrecoverable_error.html",
+            "oidc/oidc_user_data_entry.html",
+        ):
+            with self.subTest(template=name):
+                get_template(name).render({})

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -3,11 +3,14 @@
 Test that oidc urls resolve.
 """
 
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import resolve, reverse
 
 from rest_framework.renderers import JSONRenderer
+from rest_framework.viewsets import ModelViewSet
 
+from oidc.routers import UnprefixedNameRouter
 from oidc.viewsets import UserModelOpenIDConnectViewset
 
 
@@ -47,3 +50,31 @@ class TestUrls(TestCase):
         self.assertEqual(view.actions, {"get": "session"})
         self.assertEqual(view.initkwargs["authentication_classes"], [])
         self.assertEqual(view.initkwargs["renderer_classes"], [JSONRenderer])
+
+
+class TestUnprefixedNameRouterScope(TestCase):
+    """The router drops the ``{basename}-`` prefix so this package's
+    ``@action`` names survive. That must not extend to DRF's own
+    ``{basename}-list``/``-detail``: a ``VIEWSET_CLASS`` with CRUD methods
+    would come out as a bare ``list``/``detail``, which collides across
+    routers in one namespace and breaks hyperlinked serializers reversing
+    ``<model>-detail``."""
+
+    def _names(self, viewset):
+        router = UnprefixedNameRouter(trailing_slash=False)
+        router.register(r"things", viewset, basename="thing")
+        return [url.name for url in router.urls]
+
+    def test_action_names_lose_the_basename_prefix(self):
+        self.assertIn(
+            "openid_connect_login", self._names(UserModelOpenIDConnectViewset)
+        )
+
+    def test_crud_routes_keep_drfs_naming(self):
+        class ThingViewSet(ModelViewSet):
+            queryset = User.objects.all()
+            serializer_class = None
+
+        names = self._names(ThingViewSet)
+        self.assertIn("thing-list", names)
+        self.assertIn("thing-detail", names)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIRequestFactory
 from oidc.utils import (
     get_login_query_param_allowlist,
     is_safe_login_redirect,
+    str_to_bool,
 )
 
 
@@ -26,9 +27,7 @@ class TestGetLoginQueryParamAllowlist(TestCase):
             frozenset({"prompt", "ui_locales"}),
         )
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={"default": {"CLIENT_ID": "client"}}
-    )
+    @override_settings(OPENID_CONNECT_AUTH_SERVERS={"default": {"CLIENT_ID": "client"}})
     def test_returns_empty_when_key_missing(self):
         self.assertEqual(get_login_query_param_allowlist("default"), frozenset())
 
@@ -100,9 +99,7 @@ class TestIsSafeLoginRedirect(TestCase):
 
     def test_javascript_scheme_is_unsafe(self):
         self.assertFalse(
-            is_safe_login_redirect(
-                "javascript:alert(1)", "default", self._request()
-            )
+            is_safe_login_redirect("javascript:alert(1)", "default", self._request())
         )
 
     def test_protocol_relative_url_is_unsafe(self):
@@ -122,3 +119,26 @@ class TestIsSafeLoginRedirect(TestCase):
             is_safe_login_redirect(
                 "https://spa.example.com/x", "default", self._request()
             )
+
+
+class TestStrToBool(TestCase):
+    """Settings arrive from the environment as strings. Only the exact
+    literal ``"False"`` used to be falsy, so the spelling ``os.getenv``
+    hands you turned several switches *on*: ``AUTO_CREATE_USER`` created
+    the users it was set to refuse, ``USE_SSO_COOKIE`` issued the identity
+    cookie anyway, and the admin's user-import screen enabled itself."""
+
+    def test_the_spellings_of_off_are_all_false(self):
+        for value in ("False", "false", "FALSE", "0", "", "no", "off", " false "):
+            with self.subTest(value=value):
+                self.assertFalse(str_to_bool(value))
+
+    def test_the_spellings_of_on_stay_true(self):
+        for value in ("True", "true", "1", "yes", "on"):
+            with self.subTest(value=value):
+                self.assertTrue(str_to_bool(value))
+
+    def test_non_strings_pass_through(self):
+        self.assertIs(str_to_bool(True), True)
+        self.assertIs(str_to_bool(False), False)
+        self.assertIsNone(str_to_bool(None))

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1460,6 +1460,156 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(args[0], "DELETE")
         self.assertIn("/sessions?current=false", args[1])
 
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_list_forwards_keycloak_body_verbatim(self):
+        view = BaseOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        keycloak_body = [
+            {
+                "providerAlias": "google",
+                "providerName": "Google",
+                "displayName": "Google",
+                "connected": True,
+                "social": True,
+                "linkedUsername": "alice@gmail.com",
+            }
+        ]
+        upstream.json.return_value = keycloak_body
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, keycloak_body)
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_unlink_forwards_provider_alias(self):
+        view = BaseOpenIDConnectViewset.as_view({"delete": "linked_unlink"})
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+        upstream = MagicMock(status_code=204, content=b"")
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            response = view(
+                request, auth_server="default", provider="google"
+            )
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertTrue(args[1].endswith("/linked-accounts/google"))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_unlink_rejects_invalid_provider_alias(self):
+        view = BaseOpenIDConnectViewset.as_view({"delete": "linked_unlink"})
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+        with patch("oidc.client.requests.request") as mock_request:
+            response = view(
+                request, auth_server="default", provider="../etc/passwd"
+            )
+        self.assertEqual(response.status_code, 400)
+        mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_link_url_returns_account_link_uri(self):
+        view = BaseOpenIDConnectViewset.as_view(
+            {"get": "linked_link_url"}
+        )
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"{...}"
+        upstream.json.return_value = {
+            "accountLinkUri": "https://idp.example.com/realms/r/broker/google/link?nonce=n&hash=h",
+            "nonce": "n",
+            "hash": "h",
+        }
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(
+                request, auth_server="default", provider="google"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["url"],
+            "https://idp.example.com/realms/r/broker/google/link?nonce=n&hash=h",
+        )
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_credentials_list_forwards_keycloak_body(self):
+        view = BaseOpenIDConnectViewset.as_view(
+            {"get": "credentials_list"}
+        )
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        upstream.json.return_value = [
+            {
+                "type": "otp",
+                "category": "TWO_FACTOR",
+                "displayName": "Authenticator App",
+                "credentials": [
+                    {"id": "cred-1", "userLabel": "iPhone", "createdDate": 1715000000}
+                ],
+            }
+        ]
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data[0]["type"], "otp")
+
     @patch(
         "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
         MagicMock(

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1647,6 +1647,16 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         pw = response.data[1]
         self.assertEqual(pw["credentials"], [{"id": "cred-pw"}])
 
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
     def test_credentials_list_drops_rows_without_id(self):
         """A ``userCredentialMetadatas`` entry without an ``id`` can't be
         rendered as a removable row (no DELETE target, no React key), so

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -2314,6 +2314,56 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(cookie["max-age"], 0)
 
 
+class TestAccountRoutes(TestCase):
+    """URL→action wiring smoke test; per-action behaviour is covered
+    by the per-action tests above."""
+
+    def test_sessions_list_route_resolves(self):
+        from django.urls import resolve
+
+        match = resolve("/oidc/zonkey/sessions")
+        self.assertEqual(match.func.actions["get"], "sessions_list")
+
+    def test_sessions_revoke_others_route_resolves(self):
+        from django.urls import resolve
+
+        match = resolve("/oidc/zonkey/sessions")
+        self.assertEqual(match.func.actions["delete"], "sessions_revoke_others")
+
+    def test_sessions_revoke_one_route_resolves(self):
+        from django.urls import resolve
+
+        match = resolve("/oidc/zonkey/sessions/abc-123")
+        self.assertEqual(match.func.actions["delete"], "sessions_revoke_one")
+        self.assertEqual(match.kwargs["session_id"], "abc-123")
+
+    def test_linked_list_route_resolves(self):
+        from django.urls import resolve
+
+        match = resolve("/oidc/zonkey/linked-accounts")
+        self.assertEqual(match.func.actions["get"], "linked_list")
+
+    def test_linked_unlink_route_resolves(self):
+        from django.urls import resolve
+
+        match = resolve("/oidc/zonkey/linked-accounts/google")
+        self.assertEqual(match.func.actions["delete"], "linked_unlink")
+        self.assertEqual(match.kwargs["provider"], "google")
+
+    def test_linked_link_url_route_resolves(self):
+        from django.urls import resolve
+
+        match = resolve("/oidc/zonkey/linked-accounts/google/link-url")
+        self.assertEqual(match.func.actions["get"], "linked_link_url")
+        self.assertEqual(match.kwargs["provider"], "google")
+
+    def test_credentials_route_resolves(self):
+        from django.urls import resolve
+
+        match = resolve("/oidc/zonkey/credentials")
+        self.assertEqual(match.func.actions["get"], "credentials_list")
+
+
 class TestLoginNextValidation(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1585,7 +1585,16 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         },
         OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
     )
-    def test_credentials_list_forwards_keycloak_body(self):
+    def test_credentials_list_flattens_keycloak_body(self):
+        """Keycloak nests credential instances under
+        ``userCredentialMetadatas`` → ``credential`` — the SPA wants a
+        flat ``credentials`` array per category, so the proxy must
+        reshape rather than pass through. Regression test for the
+        "Authenticator app — Not set up" bug seen on stage when a user
+        had a TOTP credential but the SPA's
+        ``totpCred.credentials.length`` resolved to 0 against
+        Keycloak's real wire shape.
+        """
         view = BaseOpenIDConnectViewset.as_view(
             {"get": "credentials_list"}
         )
@@ -1597,10 +1606,67 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         upstream.json.return_value = [
             {
                 "type": "otp",
-                "category": "TWO_FACTOR",
-                "displayName": "Authenticator App",
-                "credentials": [
-                    {"id": "cred-1", "userLabel": "iPhone", "createdDate": 1715000000}
+                "category": "two-factor",
+                "displayName": "otp-display-name",
+                "userCredentialMetadatas": [
+                    {
+                        "credential": {
+                            "id": "cred-1",
+                            "type": "otp",
+                            "userLabel": "iPhone",
+                            "createdDate": 1715000000000,
+                        }
+                    }
+                ],
+            },
+            {
+                "type": "password",
+                "category": "basic-authentication",
+                "displayName": "password-display-name",
+                "userCredentialMetadatas": [
+                    {"credential": {"id": "cred-pw", "type": "password"}}
+                ],
+            },
+        ]
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        otp = response.data[0]
+        self.assertEqual(otp["type"], "otp")
+        self.assertEqual(otp["category"], "two-factor")
+        self.assertEqual(otp["displayName"], "otp-display-name")
+        self.assertEqual(len(otp["credentials"]), 1)
+        self.assertEqual(otp["credentials"][0]["id"], "cred-1")
+        self.assertEqual(otp["credentials"][0]["userLabel"], "iPhone")
+        self.assertEqual(otp["credentials"][0]["createdDate"], 1715000000000)
+        # Password row: no userLabel / createdDate in upstream → keys
+        # absent from the flattened row (the SPA renders them
+        # conditionally, so emitting "null" would add a useless empty
+        # subtitle line).
+        pw = response.data[1]
+        self.assertEqual(pw["credentials"], [{"id": "cred-pw"}])
+
+    def test_credentials_list_drops_rows_without_id(self):
+        """A ``userCredentialMetadatas`` entry without an ``id`` can't be
+        rendered as a removable row (no DELETE target, no React key), so
+        the flatten skips it rather than emitting an unactionable row."""
+        view = BaseOpenIDConnectViewset.as_view(
+            {"get": "credentials_list"}
+        )
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        upstream.json.return_value = [
+            {
+                "type": "otp",
+                "category": "two-factor",
+                "displayName": "otp-display-name",
+                "userCredentialMetadatas": [
+                    {"credential": {"userLabel": "ghost"}},
+                    {"credential": {"id": "real", "userLabel": "phone"}},
                 ],
             }
         ]
@@ -1608,7 +1674,9 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             response = view(request, auth_server="default")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data[0]["type"], "otp")
+        self.assertEqual(
+            response.data[0]["credentials"], [{"id": "real", "userLabel": "phone"}]
+        )
 
     @patch(
         "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1300,6 +1300,71 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             kwargs["headers"]["Authorization"], "Bearer stashed.access.token"
         )
 
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_list_flattens_devices_into_rows(self):
+        """Keycloak returns DeviceRepresentation[] with nested sessions[].
+        Proxy flattens to a per-session list so the SPA renders rows,
+        not nested device groups."""
+        view = BaseOpenIDConnectViewset.as_view({"get": "sessions_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        upstream.json.return_value = [
+            {
+                "browser": "Chrome",
+                "os": "macOS",
+                "current": True,
+                "sessions": [
+                    {
+                        "id": "sess-1",
+                        "ipAddress": "1.2.3.4",
+                        "started": 1715520000,
+                        "lastAccess": 1715526000,
+                        "current": True,
+                        "clients": [{"clientId": "zonkey"}],
+                    }
+                ],
+            },
+            {
+                "browser": "Firefox",
+                "os": "Windows",
+                "current": False,
+                "sessions": [
+                    {
+                        "id": "sess-2",
+                        "ipAddress": "5.6.7.8",
+                        "started": 1715500000,
+                        "lastAccess": 1715505000,
+                        "current": False,
+                        "clients": [{"clientId": "zonkey"}],
+                    }
+                ],
+            },
+        ]
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        rows = response.data
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["id"], "sess-1")
+        self.assertEqual(rows[0]["browser"], "Chrome")
+        self.assertEqual(rows[0]["os"], "macOS")
+        self.assertTrue(rows[0]["current"])
+        self.assertEqual(rows[1]["id"], "sess-2")
+        self.assertFalse(rows[1]["current"])
+
     @patch(
         "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
         MagicMock(

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1365,6 +1365,37 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(rows[1]["id"], "sess-2")
         self.assertFalse(rows[1]["current"])
 
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_revoke_others_passes_current_false(self):
+        """DELETE /sessions revokes every session EXCEPT the current one."""
+        view = BaseOpenIDConnectViewset.as_view(
+            {"delete": "sessions_revoke_others"}
+        )
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=204, content=b"")
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            response = view(request, auth_server="default")
+
+        # 204 No Content is Keycloak's natural success code for DELETE;
+        # passed through verbatim so the SPA can treat `res.ok` uniformly.
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertEqual(args[0], "DELETE")
+        self.assertIn("/sessions?current=false", args[1])
+
     @patch(
         "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
         MagicMock(

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1375,6 +1375,70 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         },
         OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
     )
+    def test_sessions_revoke_one_forwards_id(self):
+        view = BaseOpenIDConnectViewset.as_view(
+            {"delete": "sessions_revoke_one"}
+        )
+        request = self.factory.delete("/")
+        request.session = {
+            "oidc_access_token": "stashed.access.token",
+            "oidc_id_token": "header.payload.sig",
+        }
+        upstream = MagicMock(status_code=204, content=b"")
+        with patch(
+            "oidc.viewsets._sid_from_id_token", return_value="current-sid"
+        ), patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            response = view(
+                request, auth_server="default", session_id="other-sid"
+            )
+
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertEqual(args[0], "DELETE")
+        self.assertTrue(args[1].endswith("/sessions/other-sid"))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_revoke_one_rejects_current_session(self):
+        view = BaseOpenIDConnectViewset.as_view(
+            {"delete": "sessions_revoke_one"}
+        )
+        request = self.factory.delete("/")
+        request.session = {
+            "oidc_access_token": "stashed.access.token",
+            "oidc_id_token": "header.payload.sig",
+        }
+        with patch(
+            "oidc.viewsets._sid_from_id_token", return_value="current-sid"
+        ), patch("oidc.client.requests.request") as mock_request:
+            response = view(
+                request, auth_server="default", session_id="current-sid"
+            )
+
+        self.assertEqual(response.status_code, 409)
+        # Crucial: we never reach Keycloak.
+        mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
     def test_sessions_revoke_others_passes_current_false(self):
         """DELETE /sessions revokes every session EXCEPT the current one."""
         view = BaseOpenIDConnectViewset.as_view(

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1106,12 +1106,12 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             "/", data={"email": "new@example.com"}, format="json"
         )
         request.session = {}
-        with patch("oidc.client.requests.post") as mock_post:
+        with patch("oidc.client.requests.request") as mock_request:
             response = view(request, auth_server="default")
 
         self.assertEqual(response.status_code, 401)
         # Critical: we never reached out to Keycloak.
-        mock_post.assert_not_called()
+        mock_request.assert_not_called()
 
     @override_settings(
         OPENID_CONNECT_AUTH_SERVERS={
@@ -1144,13 +1144,13 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         mock_response.status_code = 204
         mock_response.content = b""
         with patch(
-            "oidc.client.requests.post", return_value=mock_response
-        ) as mock_post:
+            "oidc.client.requests.request", return_value=mock_response
+        ) as mock_request:
             response = view(request, auth_server="default")
 
         self.assertEqual(response.status_code, 200)
         # Bearer auth uses the stashed token.
-        _args, kwargs = mock_post.call_args
+        _args, kwargs = mock_request.call_args
         self.assertEqual(
             kwargs["headers"]["Authorization"], "Bearer stashed.access.token"
         )
@@ -1176,11 +1176,11 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         )
         request.session = {"oidc_access_token": "stashed.access.token"}
 
-        with patch("oidc.client.requests.post") as mock_post:
+        with patch("oidc.client.requests.request") as mock_request:
             response = view(request, auth_server="default")
 
         self.assertEqual(response.status_code, 400)
-        mock_post.assert_not_called()
+        mock_request.assert_not_called()
 
     @override_settings(
         OPENID_CONNECT_AUTH_SERVERS={
@@ -1216,16 +1216,20 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         second_call = MagicMock(status_code=204, content=b"")
 
         with patch(
-            "oidc.client.requests.post",
-            side_effect=[first_call, refresh_call, second_call],
+            "oidc.client.requests.request",
+            side_effect=[first_call, second_call],
+        ) as mock_request, patch(
+            "oidc.client.requests.post", return_value=refresh_call
         ) as mock_post:
             response = view(request, auth_server="default")
 
         self.assertEqual(response.status_code, 200)
-        # Three calls: account (401) → token (refresh) → account (retry, 204).
-        self.assertEqual(mock_post.call_count, 3)
+        # Two account calls (POST 401 → POST 204) plus one token refresh
+        # POST against ``token_endpoint``.
+        self.assertEqual(mock_request.call_count, 2)
+        self.assertEqual(mock_post.call_count, 1)
         # Retry used the fresh token.
-        _args, kwargs = mock_post.call_args_list[2]
+        _args, kwargs = mock_request.call_args_list[1]
         self.assertEqual(
             kwargs["headers"]["Authorization"], "Bearer fresh.access.token"
         )
@@ -1256,6 +1260,45 @@ class TestUserModelOpenIDConnectViewset(TestCase):
 
         self.assertEqual(response.status_code, 503)
         mock_post.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_keycloak_account_request_get_passes_through_status_and_body(self):
+        """Shared helper round-trips method/path/body and surfaces upstream
+        (status, body). Refresh + retry exists already; this locks the
+        plain happy-path so the helper extraction is observably safe."""
+        viewset = BaseOpenIDConnectViewset()
+        client = OpenIDClient("default")
+        session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200, content=b'{"hello":"world"}')
+        upstream.json.return_value = {"hello": "world"}
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            status, body = viewset._keycloak_account_request(
+                client, session, "GET", "/sessions/devices"
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(body, {"hello": "world"})
+        args, kwargs = mock_request.call_args
+        self.assertEqual(args[0], "GET")
+        self.assertEqual(
+            args[1],
+            "https://idp.example.com/realms/r/account/sessions/devices",
+        )
+        self.assertEqual(
+            kwargs["headers"]["Authorization"], "Bearer stashed.access.token"
+        )
 
     @patch(
         "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -4197,6 +4197,44 @@ class TestPendingTokensBelongToOneFlow(TestCase):
             "access-alice",
         )
 
+    def test_a_body_it_cannot_parse_does_not_replace_the_real_error(self):
+        """The drain runs in a ``finally`` and needs the request's id_token.
+        Reading it through DRF's lazy parse means an unparseable body raises
+        *there* -- second, so it displaces whatever was already on its way
+        out, and a real defect reaches the browser as a content-type
+        complaint with nothing logged."""
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        for body, content_type in (
+            ("<x/>", "application/xml"),
+            ("{not json", "application/json"),
+            ("[1,2]", "application/json"),
+        ):
+            with self.subTest(body=body):
+                with patch.object(
+                    UserModelOpenIDConnectViewset,
+                    "_callback",
+                    side_effect=RuntimeError("a real bug"),
+                ):
+                    request = self.factory.post(
+                        "/", data=body, content_type=content_type
+                    )
+                    request.session = {}
+                    with self.assertRaises(RuntimeError):
+                        view(request, auth_server="default")
+
+    def test_an_unparseable_body_still_gets_the_handled_error(self):
+        """The same read on the unknown-auth_server path, which answers 400
+        and never looks at the body itself."""
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        for body in ("[1,2]", '"hello"', "null"):
+            with self.subTest(body=body):
+                request = self.factory.post(
+                    "/", data=body, content_type="application/json"
+                )
+                request.session = {}
+                response = view(request, auth_server="nosuchserver")
+                self.assertEqual(response.status_code, 400)
+
     def test_a_callback_that_raises_still_gives_the_pair_up(self):
         """An id_token shape this library has no handler for raises past
         every ``except`` and becomes a 500. That is an exit too, and the
@@ -4222,6 +4260,54 @@ class TestPendingTokensBelongToOneFlow(TestCase):
                 view(request, auth_server="default")
 
         self.assertEqual([k for k in session if k.endswith(":pending")], [])
+
+    def test_a_reskinned_form_keeps_its_pair_across_a_retry(self):
+        """The exempt exit is the username form, not one template path. A
+        deployment that renders its own form still parks a pair in the base
+        method, and draining it would leave that deployment signed in with
+        no pair the moment a user mistypes a username once."""
+        from tests.project_viewsets import ReskinnedFormViewset
+
+        session = {}
+        view = ReskinnedFormViewset.as_view({"post": "callback"})
+        claims = {"given_name": "Alice", "family_name": "User", "email": "a@x.io"}
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value={
+                    "id_token": "id-token-alice",
+                    "access_token": "access-alice",
+                    "refresh_token": "refresh-alice",
+                },
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value=claims,
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = session
+            first = view(request, auth_server="default")
+        self.assertEqual(first.template_name, "oidc/my_own_user_form.html")
+        self._assert_still_parked(session, "alice")
+
+        User.objects.create(username="taken_name", email="someone@x.io")
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+            return_value=claims,
+        ):
+            request = self.factory.post(
+                "/",
+                data={
+                    "id_token": "id-token-alice",
+                    "username": "taken_name",
+                    USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+                },
+            )
+            request.session = session
+            view(request, auth_server="default")
+
+        self._assert_still_parked(session, "alice")
 
     def test_logout_clears_a_pair_abandoned_at_the_form(self):
         """Nothing can tell an abandoned pair from one whose tab is still on
@@ -4924,6 +5010,59 @@ class TestAccountCallFailureModes(TestCase):
         request.session = {}
         self.assertEqual(view(request, auth_server="default").status_code, 401)
 
+    def test_a_redirect_is_a_502_not_a_redirect_of_our_own(self):
+        """We ask not to follow it, so it lands here. Forwarding the status
+        verbatim re-emits a redirect from our own origin with no Location --
+        and a 301 is cacheable."""
+        for code in (301, 302, 307):
+            with self.subTest(code=code):
+                upstream = MagicMock(status_code=code, content=b"")
+                response = self._get(return_value=upstream)
+                self.assertEqual(response.status_code, 502)
+
+    def test_a_refresh_that_answers_with_html_is_a_502(self):
+        """Same failure as on the account call, one endpoint over: a
+        maintenance page in front of TOKEN_ENDPOINT used to escape as a bare
+        ValueError and 500."""
+        first = MagicMock(status_code=401, content=b"{}")
+        first.json.return_value = {"error": "invalid_token"}
+        refresh = MagicMock(status_code=200, content=b"<html>maintenance</html>")
+        refresh.json.side_effect = ValueError("Expecting value")
+
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {
+            token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"): "old",
+            token_session_key(REFRESH_TOKEN_SESSION_KEY, "default"): "rt",
+        }
+        with (
+            patch("oidc.client.requests.request", return_value=first),
+            patch("oidc.client.requests.post", return_value=refresh),
+        ):
+            response = view(request, auth_server="default")
+        self.assertEqual(response.status_code, 502)
+
+    def test_the_refresh_call_does_not_follow_redirects_either(self):
+        tokens = MagicMock(status_code=200, content=b"{}")
+        tokens.json.return_value = {"access_token": "new"}
+        first = MagicMock(status_code=401, content=b"{}")
+        first.json.return_value = {"error": "invalid_token"}
+        retry = MagicMock(status_code=200, content=b"[]")
+        retry.json.return_value = []
+
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {
+            token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"): "old",
+            token_session_key(REFRESH_TOKEN_SESSION_KEY, "default"): "rt",
+        }
+        with (
+            patch("oidc.client.requests.request", side_effect=[first, retry]),
+            patch("oidc.client.requests.post", return_value=tokens) as post,
+        ):
+            view(request, auth_server="default")
+        self.assertIs(post.call_args.kwargs["allow_redirects"], False)
+
     def test_an_empty_2xx_body_is_still_a_success(self):
         """A declared shape must not turn "nothing to send back" into a
         gateway error -- a 204 carries no body by definition."""
@@ -5406,6 +5545,54 @@ class TestDeployCheckComparesRoutesNotNames(TestCase):
         describe exactly this override."""
         errors = check_actions_survive_subclassing(None)
         self.assertEqual([e.id for e in errors], ["oidc.E002"])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.UnguardedAuthClassesViewset",
+        }
+    )
+    def test_dropping_only_authentication_classes_is_reported(self):
+        """``authentication_classes=[]`` is declared empty on purpose, and
+        an empty set is a subset of anything -- so a comparison by content
+        alone can never notice it going missing. The override inherits
+        SessionAuthentication, whose CSRF check then rejects the SPA's own
+        DELETEs."""
+        errors = check_actions_survive_subclassing(None)
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.ComposedPermissionViewset",
+        }
+    )
+    def test_tightening_by_composition_is_not_reported(self):
+        """``A & B`` collapses to one OperandHolder, so the shipped class is
+        no longer literally in the list even though the route still demands
+        it."""
+        self.assertEqual(check_actions_survive_subclassing(None), [])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.WidenedPermissionViewset",
+        }
+    )
+    def test_widening_by_composition_is_still_reported(self):
+        """``A | B`` has the same shape as the case above and the opposite
+        meaning: the route now admits anything B admits."""
+        errors = check_actions_survive_subclassing(None)
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.ExtraVerbViewset",
+        }
+    )
+    def test_adding_a_verb_is_not_reported(self):
+        self.assertEqual(check_actions_survive_subclassing(None), [])
 
     @override_settings(
         OPENID_CONNECT_VIEWSET_CONFIG={

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -3,29 +3,47 @@ Tests for the OpenID Client
 """
 
 import json
+import logging
+from types import SimpleNamespace
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.urls import Resolver404, get_resolver, resolve
 from django.utils import timezone
 
 import jwt
+import requests
 from mock import MagicMock, patch
 from rest_framework.test import APIRequestFactory
 
+from oidc.checks import check_session_backend_can_hold_tokens
 from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
+from oidc.keycloak import KeycloakOpenIDConnectViewset
+from oidc.permissions import IsCsrfSafeAccountRequest, get_account_request_header
+from oidc.urls import get_viewset_class
+from oidc.utils import (
+    ACCESS_TOKEN_SESSION_KEY,
+    ID_TOKEN_SESSION_KEY,
+    REFRESH_TOKEN_SESSION_KEY,
+    pending_token_session_key,
+    token_session_key,
+)
+from tests.project_viewsets import InjectedViewset
 from oidc.viewsets import (
     DEFAULT_USERNAME_HELP_TEXT,
     DEFAULT_USERNAME_PATTERN,
     USERNAME_FORM_MARKER_FIELD,
     USERNAME_FORM_MARKER_VALUE,
     BaseOpenIDConnectViewset,
+    RapidProOpenIDConnectViewset,
     UserModelOpenIDConnectViewset,
 )
 
 User = get_user_model()
+
 
 OPENID_CONNECT_AUTH_SERVERS = {
     "default": {
@@ -1000,7 +1018,10 @@ class TestUserModelOpenIDConnectViewset(TestCase):
 
         request = self.factory.get("/")
         # Stand in for ``SessionMiddleware`` — APIRequestFactory skips it.
-        request.session = {"oidc_id_token": "ey.signed.jwt", "unrelated": "keep"}
+        request.session = {
+            "oidc_id_token:default": "ey.signed.jwt",
+            "unrelated": "keep",
+        }
         response = view(request, auth_server="default")
 
         self.assertEqual(response.status_code, 302)
@@ -1009,7 +1030,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             "http://localhost:3000?id_token_hint=ey.signed.jwt",
         )
         # Pop, not get — the token must not outlive the session it served.
-        self.assertNotIn("oidc_id_token", request.session)
+        self.assertNotIn("oidc_id_token:default", request.session)
         self.assertEqual(request.session.get("unrelated"), "keep")
 
     @override_settings(
@@ -1064,7 +1085,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         view = BaseOpenIDConnectViewset.as_view({"get": "logout"})
 
         request = self.factory.get("/?id_token_hint=ey.attacker.jwt")
-        request.session = {"oidc_id_token": "ey.legit.jwt"}
+        request.session = {"oidc_id_token:default": "ey.legit.jwt"}
         response = view(request, auth_server="default")
 
         self.assertEqual(response.status_code, 302)
@@ -1087,6 +1108,614 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(response.status_code, 302)
         # End-session URL untouched — bare endpoint, no stray `?`/`&`.
         self.assertEqual(response.url, "http://localhost:3000")
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_proxy_no_session_token_returns_401(self):
+        """No stashed access_token → 401, never reach Keycloak."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+
+        request = self.factory.get("/")
+        request.session = {}
+        with patch("oidc.client.requests.request") as mock_request:
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 401)
+        # Critical: we never reached out to Keycloak.
+        mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_proxy_refresh_rejected_by_idp_returns_401(self):
+        """The IdP answered and refused the refresh token: the session really
+        is dead, so signing in again is the right instruction."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {
+            "oidc_access_token:default": "expired.access.token",
+            "oidc_refresh_token:default": "revoked.refresh.token",
+        }
+
+        first_call = MagicMock(status_code=401, content=b"{}")
+        first_call.json.return_value = {"error": "invalid_token"}
+        refresh_call = MagicMock(status_code=400)
+        refresh_call.raise_for_status.side_effect = requests.HTTPError("400")
+
+        with (
+            patch("oidc.client.requests.request", return_value=first_call),
+            patch("oidc.client.requests.post", return_value=refresh_call),
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 401)
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_proxy_refresh_transport_failure_returns_502(self):
+        """Pin: an unreachable IdP must not be reported as an expired session.
+        Doing so sends the user through a re-login that cannot fix a server
+        problem."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {
+            "oidc_access_token:default": "expired.access.token",
+            "oidc_refresh_token:default": "stashed.refresh.token",
+        }
+
+        first_call = MagicMock(status_code=401, content=b"{}")
+        first_call.json.return_value = {"error": "invalid_token"}
+
+        with (
+            patch("oidc.client.requests.request", return_value=first_call),
+            patch(
+                "oidc.client.requests.post",
+                side_effect=requests.ConnectionError("idp unreachable"),
+            ),
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 502)
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_proxy_does_not_disguise_our_own_bugs_as_upstream_failures(self):
+        """Pin: only transport/config errors become 502. A defect in our own
+        response handling must surface as a 500 with a traceback, not as
+        'could not reach the identity provider' pointing at Keycloak."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "credentials_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token:default": "t"}
+
+        with patch.object(
+            KeycloakOpenIDConnectViewset,
+            "_keycloak_account_request",
+            side_effect=KeyError("bug in transform"),
+        ):
+            with self.assertRaises(KeyError):
+                view(request, auth_server="default")
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_proxy_refreshes_on_401_and_retries(self):
+        """Keycloak 401 → refresh access_token via refresh_token → retry.
+        Session writeback so the next request uses the fresh token."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+
+        request = self.factory.get("/")
+        request.session = {
+            "oidc_access_token:default": "expired.access.token",
+            "oidc_refresh_token:default": "stashed.refresh.token",
+        }
+
+        first_call = MagicMock(status_code=401, content=b"{}")
+        first_call.json.return_value = {"error": "invalid_token"}
+        refresh_call = MagicMock(status_code=200)
+        refresh_call.json.return_value = {
+            "access_token": "fresh.access.token",
+            "refresh_token": "fresh.refresh.token",
+        }
+        refresh_call.raise_for_status = MagicMock()
+        second_call = MagicMock(status_code=200, content=b"[]")
+        second_call.json.return_value = []
+
+        with (
+            patch(
+                "oidc.client.requests.request",
+                side_effect=[first_call, second_call],
+            ) as mock_request,
+            patch("oidc.client.requests.post", return_value=refresh_call) as mock_post,
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        # Two account calls (GET 401 → GET 200) plus one token refresh
+        # POST against ``token_endpoint``.
+        self.assertEqual(mock_request.call_count, 2)
+        self.assertEqual(mock_post.call_count, 1)
+        # Retry used the fresh token.
+        _args, kwargs = mock_request.call_args_list[1]
+        self.assertEqual(
+            kwargs["headers"]["Authorization"], "Bearer fresh.access.token"
+        )
+        # Session was updated with the fresh tokens.
+        self.assertEqual(
+            request.session["oidc_access_token:default"], "fresh.access.token"
+        )
+        self.assertEqual(
+            request.session["oidc_refresh_token:default"], "fresh.refresh.token"
+        )
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_proxy_returns_503_when_endpoint_not_configured(self):
+        """Deployments that haven't wired ``ACCOUNT_ENDPOINT`` get a
+        clear 503 — never reach Keycloak with a half-baked URL."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+
+        with patch("oidc.client.requests.post") as mock_post:
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 503)
+        mock_post.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_keycloak_account_request_get_passes_through_status_and_body(self):
+        """Shared helper round-trips method/path/body and surfaces upstream
+        (status, body). Refresh + retry exists already; this locks the
+        plain happy-path so the helper extraction is observably safe."""
+        viewset = KeycloakOpenIDConnectViewset()
+        client = OpenIDClient("default")
+        session = {"oidc_access_token:default": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200, content=b'{"hello":"world"}')
+        upstream.json.return_value = {"hello": "world"}
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            status, body = viewset._keycloak_account_request(
+                client, session, "GET", "/sessions/devices"
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(body, {"hello": "world"})
+        args, kwargs = mock_request.call_args
+        self.assertEqual(args[0], "GET")
+        self.assertEqual(
+            args[1],
+            "https://idp.example.com/realms/r/account/sessions/devices",
+        )
+        self.assertEqual(
+            kwargs["headers"]["Authorization"], "Bearer stashed.access.token"
+        )
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_list_flattens_devices_into_rows(self):
+        """Keycloak returns DeviceRepresentation[] with nested sessions[].
+        Proxy flattens to a per-session list so the SPA renders rows,
+        not nested device groups. NOTE: ``browser`` lives on each nested
+        session, while ``os`` is on the device — so the flattened row's
+        browser must come from the session, not the device."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "sessions_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        upstream.json.return_value = [
+            {
+                "os": "macOS",
+                "current": True,
+                "sessions": [
+                    {
+                        "id": "sess-1",
+                        "browser": "Chrome",
+                        "ipAddress": "1.2.3.4",
+                        "started": 1715520000,
+                        "lastAccess": 1715526000,
+                        "current": True,
+                        "clients": [{"clientId": "example"}],
+                    }
+                ],
+            },
+            {
+                "os": "Windows",
+                "current": False,
+                "sessions": [
+                    {
+                        "id": "sess-2",
+                        "browser": "Firefox",
+                        "ipAddress": "5.6.7.8",
+                        "started": 1715500000,
+                        "lastAccess": 1715505000,
+                        "current": False,
+                        "clients": [{"clientId": "example"}],
+                    }
+                ],
+            },
+        ]
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        rows = response.data
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["id"], "sess-1")
+        self.assertEqual(rows[0]["browser"], "Chrome")
+        self.assertEqual(rows[0]["os"], "macOS")
+        self.assertTrue(rows[0]["current"])
+        self.assertEqual(rows[1]["id"], "sess-2")
+        self.assertEqual(rows[1]["browser"], "Firefox")
+        self.assertEqual(rows[1]["os"], "Windows")
+        self.assertFalse(rows[1]["current"])
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_list_marks_only_sid_match_current_when_grouped(self):
+        """Two browsers on one machine (e.g. normal + incognito on
+        localhost) collapse into a single device that Keycloak flags
+        ``current``, with both nested sessions flagged ``current`` too.
+        Only the session whose id matches the id_token ``sid`` should
+        render as current — not both."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "sessions_list"})
+        request = self.factory.get("/")
+        request.session = {
+            "oidc_access_token:default": "stashed.access.token",
+            "oidc_id_token:default": "stashed.id.token",
+        }
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        upstream.json.return_value = [
+            {
+                "browser": "Chrome",
+                "os": "Mac OS X",
+                "current": True,
+                "sessions": [
+                    {"id": "sess-old", "current": True, "clients": []},
+                    {"id": "sess-current", "current": True, "clients": []},
+                ],
+            },
+        ]
+        with (
+            patch("oidc.keycloak._sid_from_id_token", return_value="sess-current"),
+            patch("oidc.client.requests.request", return_value=upstream),
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        by_id = {row["id"]: row for row in response.data}
+        self.assertFalse(by_id["sess-old"]["current"])
+        self.assertTrue(by_id["sess-current"]["current"])
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_revoke_one_forwards_id(self):
+        view = KeycloakOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
+        request = self.factory.delete("/")
+        request.session = {
+            "oidc_access_token:default": "stashed.access.token",
+            "oidc_id_token:default": "header.payload.sig",
+        }
+        upstream = MagicMock(status_code=204, content=b"")
+        with (
+            patch("oidc.keycloak._sid_from_id_token", return_value="current-sid"),
+            patch(
+                "oidc.client.requests.request", return_value=upstream
+            ) as mock_request,
+        ):
+            response = view(request, auth_server="default", session_id="other-sid")
+
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertEqual(args[0], "DELETE")
+        self.assertTrue(args[1].endswith("/sessions/other-sid"))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_revoke_one_rejects_current_session(self):
+        view = KeycloakOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
+        request = self.factory.delete("/")
+        request.session = {
+            "oidc_access_token:default": "stashed.access.token",
+            "oidc_id_token:default": "header.payload.sig",
+        }
+        with (
+            patch("oidc.keycloak._sid_from_id_token", return_value="current-sid"),
+            patch("oidc.client.requests.request") as mock_request,
+        ):
+            response = view(request, auth_server="default", session_id="current-sid")
+
+        self.assertEqual(response.status_code, 409)
+        # Crucial: we never reach Keycloak.
+        mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_revoke_others_passes_current_false(self):
+        """DELETE /sessions revokes every session EXCEPT the current one."""
+        view = KeycloakOpenIDConnectViewset.as_view(
+            {"delete": "sessions_revoke_others"}
+        )
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=204, content=b"")
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            response = view(request, auth_server="default")
+
+        # 204 No Content is Keycloak's natural success code for DELETE;
+        # passed through verbatim so the SPA can treat `res.ok` uniformly.
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertEqual(args[0], "DELETE")
+        self.assertIn("/sessions?current=false", args[1])
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_list_forwards_keycloak_body_verbatim(self):
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        keycloak_body = [
+            {
+                "providerAlias": "google",
+                "providerName": "Google",
+                "displayName": "Google",
+                "connected": True,
+                "social": True,
+                "linkedUsername": "alice@gmail.com",
+            }
+        ]
+        upstream.json.return_value = keycloak_body
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, keycloak_body)
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_unlink_forwards_provider_alias(self):
+        view = KeycloakOpenIDConnectViewset.as_view({"delete": "linked_unlink"})
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+        upstream = MagicMock(status_code=204, content=b"")
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            response = view(request, auth_server="default", provider="google")
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertTrue(args[1].endswith("/linked-accounts/google"))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_unlink_rejects_invalid_provider_alias(self):
+        view = KeycloakOpenIDConnectViewset.as_view({"delete": "linked_unlink"})
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+        with patch("oidc.client.requests.request") as mock_request:
+            response = view(request, auth_server="default", provider="../etc/passwd")
+        self.assertEqual(response.status_code, 400)
+        mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_link_url_forwards_body(self):
+        """The link-url action forwards Keycloak's linked-account
+        representation verbatim — the SPA extracts ``accountLinkUri``
+        client-side."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_link_url"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"{...}"
+        upstream.json.return_value = {
+            "accountLinkUri": "https://idp.example.com/realms/r/broker/google/link?nonce=n&hash=h",
+            "nonce": "n",
+            "hash": "h",
+        }
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default", provider="google")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "accountLinkUri": (
+                    "https://idp.example.com/realms/r/broker/google/link"
+                    "?nonce=n&hash=h"
+                ),
+                "nonce": "n",
+                "hash": "h",
+            },
+        )
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_credentials_list_forwards_body(self):
+        """The credentials action forwards Keycloak's nested
+        credential-metadata wire shape verbatim — reshaping for
+        rendering (flattening ``userCredentialMetadatas`` →
+        ``credential``) happens client-side in the SPA."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "credentials_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+
+        upstream_body = [
+            {
+                "type": "otp",
+                "category": "two-factor",
+                "displayName": "otp-display-name",
+                "userCredentialMetadatas": [
+                    {
+                        "credential": {
+                            "id": "cred-1",
+                            "type": "otp",
+                            "userLabel": "iPhone",
+                            "createdDate": 1715000000000,
+                        }
+                    }
+                ],
+            },
+            {
+                "type": "password",
+                "category": "basic-authentication",
+                "displayName": "password-display-name",
+                "userCredentialMetadatas": [
+                    {"credential": {"id": "cred-pw", "type": "password"}}
+                ],
+            },
+        ]
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        upstream.json.return_value = upstream_body
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, upstream_body)
 
     @patch(
         "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
@@ -1792,6 +2421,133 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(cookie["max-age"], 0)
 
 
+class TestViewsetClassInjection(TestCase):
+    """Which viewset ``oidc.urls`` routes to.
+
+    Without injection a deployment that needs its own subclass has to copy the
+    whole URLconf, then mirror every future route and view kwarg by hand.
+    """
+
+    def test_defaults_to_the_user_model_viewset(self):
+        self.assertIs(get_viewset_class(), UserModelOpenIDConnectViewset)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "USE_RAPIDPRO_VIEWSET": True,
+        }
+    )
+    def test_rapidpro_boolean_still_honoured(self):
+        """Back-compat: the older boolean form keeps working."""
+        self.assertIs(get_viewset_class(), RapidProOpenIDConnectViewset)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.InjectedViewset",
+        }
+    )
+    def test_dotted_path_routes_to_a_project_subclass(self):
+        self.assertIs(get_viewset_class(), InjectedViewset)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.InjectedViewset",
+            "USE_RAPIDPRO_VIEWSET": True,
+        }
+    )
+    def test_dotted_path_wins_over_the_boolean(self):
+        """Pin the precedence: a deployment that names a class means it."""
+        self.assertIs(get_viewset_class(), InjectedViewset)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.NoSuchViewset",
+        }
+    )
+    def test_unimportable_path_fails_loudly(self):
+        """A typo must not silently fall back to the default viewset — that
+        would drop a subclass's access rules with nothing to notice it."""
+        with self.assertRaises(ImportError):
+            get_viewset_class()
+
+
+@override_settings(ROOT_URLCONF="tests.keycloak_urls")
+class TestAccountRoutes(TestCase):
+    """URL→action wiring smoke test; per-action behaviour is covered
+    by the per-action tests above."""
+
+    ROUTES = (
+        ("/oidc/example/sessions", "get", "sessions_list", {}),
+        ("/oidc/example/sessions", "delete", "sessions_revoke_others", {}),
+        (
+            "/oidc/example/sessions/abc-123",
+            "delete",
+            "sessions_revoke_one",
+            {"session_id": "abc-123"},
+        ),
+        ("/oidc/example/linked-accounts", "get", "linked_list", {}),
+        (
+            "/oidc/example/linked-accounts/google",
+            "delete",
+            "linked_unlink",
+            {"provider": "google"},
+        ),
+        (
+            "/oidc/example/linked-accounts/google/link-url",
+            "get",
+            "linked_link_url",
+            {"provider": "google"},
+        ),
+        ("/oidc/example/credentials", "get", "credentials_list", {}),
+    )
+
+    def test_routes_resolve_to_their_actions(self):
+        for path, method, action, url_kwargs in self.ROUTES:
+            with self.subTest(path=path, method=method):
+                match = resolve(path)
+                self.assertEqual(match.func.actions[method], action)
+                for key, value in url_kwargs.items():
+                    self.assertEqual(match.kwargs[key], value)
+
+    def test_every_proxy_route_carries_the_csrf_permission(self):
+        """Each action declares its own gate, so an action added without one
+        would be routed and unguarded.
+
+        Enumerated from the router rather than from ``ROUTES``: checking a
+        hand-written list only proves the routes someone remembered to add to
+        it, which is exactly the case that never fails.
+
+        Both keys matter: empty ``authentication_classes`` is what takes these
+        routes out of DRF's SessionAuthentication/CSRF path, and the permission
+        is what replaces it. Either one alone is a hole.
+        """
+        proxy_actions = {
+            a.__name__ for a in KeycloakOpenIDConnectViewset.get_extra_actions()
+        } - {a.__name__ for a in UserModelOpenIDConnectViewset.get_extra_actions()}
+        self.assertTrue(proxy_actions, "no proxy actions found — check the mixin")
+
+        reached = set()
+        for pattern in get_resolver().url_patterns:
+            view = pattern.callback
+            handled = set(getattr(view, "actions", {}).values())
+            if not handled & proxy_actions:
+                continue
+            with self.subTest(pattern=str(pattern.pattern)):
+                initkwargs = view.initkwargs
+                self.assertIn(
+                    IsCsrfSafeAccountRequest,
+                    initkwargs.get("permission_classes", []),
+                )
+                self.assertEqual(initkwargs.get("authentication_classes"), [])
+            reached |= handled & proxy_actions
+
+        # Every proxy action is actually routed, so none slipped past the loop.
+        self.assertEqual(reached, proxy_actions)
+
+
 class TestLoginNextValidation(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
@@ -2205,3 +2961,1748 @@ class TestSessionAction(TestCase):
         )
         self.assertEqual(response.status_code, 401)
         self.assertFalse(response.has_header("WWW-Authenticate"))
+
+
+@override_settings(ROOT_URLCONF="tests.keycloak_urls")
+class AccountProxyCsrfTests(TestCase):
+    """CSRF gate on the state-changing account-proxy actions: unsafe methods
+    require a custom header AND a trusted Origin."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.perm = IsCsrfSafeAccountRequest()
+        self.view = SimpleNamespace(kwargs={"auth_server": "default"})
+        self.header_kwarg = {
+            "HTTP_" + get_account_request_header().upper().replace("-", "_"): "1"
+        }
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "ACCOUNT_REQUEST_HEADER": "X-Acme-Account-Request",
+        }
+    )
+    def test_configured_header_replaces_the_default(self):
+        """A deployment that renames the header is gated on its own name, and
+        the shipped default stops working — otherwise the setting would only
+        widen what is accepted rather than move it."""
+        configured = self.factory.post("/", HTTP_X_ACME_ACCOUNT_REQUEST="1")
+        self.assertTrue(self.perm.has_permission(configured, self.view))
+
+        shipped_default = self.factory.post("/", HTTP_X_ONA_ACCOUNT_REQUEST="1")
+        self.assertFalse(self.perm.has_permission(shipped_default, self.view))
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "ACCOUNT_REQUEST_HEADER": "X-Acme-Account-Request",
+        }
+    )
+    def test_denial_message_names_the_configured_header(self):
+        """Pin: the message is resolved per request. As a class-level f-string
+        it would freeze the default at import and tell operators to send a
+        header the deployment no longer accepts."""
+        self.assertIn("X-Acme-Account-Request", self.perm.message)
+        self.assertNotIn("X-Ona-Account-Request", self.perm.message)
+
+    def test_defaults_to_the_shipped_header_when_unconfigured(self):
+        self.assertEqual(get_account_request_header(), "X-Ona-Account-Request")
+
+    def test_safe_method_needs_no_header(self):
+        """GET/HEAD/OPTIONS need no header — the Origin allowlist still
+        applies to them; see TestReadsAreOriginGated."""
+        self.assertTrue(self.perm.has_permission(self.factory.get("/"), self.view))
+
+    def test_unsafe_without_header_denied(self):
+        """POST/DELETE without the header are refused by the permission."""
+        self.assertFalse(self.perm.has_permission(self.factory.post("/"), self.view))
+        self.assertFalse(self.perm.has_permission(self.factory.delete("/"), self.view))
+
+    def test_unsafe_with_header_no_origin_allowed(self):
+        """Header + no Origin (same-origin requests may omit it) → allowed."""
+        request = self.factory.post("/", **self.header_kwarg)
+        self.assertTrue(self.perm.has_permission(request, self.view))
+
+    def test_unsafe_same_origin_allowed(self):
+        """Header + the request's own origin → allowed."""
+        request = self.factory.post(
+            "/", HTTP_ORIGIN="http://testserver", **self.header_kwarg
+        )
+        self.assertTrue(self.perm.has_permission(request, self.view))
+
+    def test_unsafe_untrusted_origin_denied(self):
+        """Header present but a foreign Origin → refused. This is the layer
+        that holds even if the deployment's CORS is permissive."""
+        request = self.factory.post(
+            "/", HTTP_ORIGIN="https://evil.example", **self.header_kwarg
+        )
+        self.assertFalse(self.perm.has_permission(request, self.view))
+
+    def test_unsafe_null_origin_denied(self):
+        """Origin: null (sandboxed iframe / opaque origin) is host-less and
+        must not be treated as same-origin-safe."""
+        request = self.factory.post("/", HTTP_ORIGIN="null", **self.header_kwarg)
+        self.assertFalse(self.perm.has_permission(request, self.view))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "LOGIN_REDIRECT_ALLOWED_HOSTS": ["app.example.com"],
+            },
+        }
+    )
+    def test_unsafe_allowlisted_cross_origin_allowed(self):
+        """A configured SPA origin (via LOGIN_REDIRECT_ALLOWED_HOSTS) → ok."""
+        request = self.factory.post(
+            "/", HTTP_ORIGIN="https://app.example.com", **self.header_kwarg
+        )
+        self.assertTrue(self.perm.has_permission(request, self.view))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_permitted_request_reaches_the_action(self):
+        """Header + no cross-origin Origin: the permission passes and the
+        action runs through to a concrete success."""
+        view = KeycloakOpenIDConnectViewset.as_view(
+            {"delete": "sessions_revoke_others"},
+            authentication_classes=[],
+            permission_classes=[IsCsrfSafeAccountRequest],
+        )
+        request = self.factory.delete("/", **self.header_kwarg)
+        request.session = {"oidc_access_token:default": "t"}
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.content = b""
+        with patch("oidc.client.requests.request", return_value=mock_response):
+            response = view(request, auth_server="default")
+        self.assertEqual(response.status_code, 204)
+
+
+class TestKeycloakProxyIsOptIn(TestCase):
+    """The account proxy is Keycloak's, so the provider-neutral viewset must
+    not carry it and a deployment that doesn't opt in gets no routes for it."""
+
+    ACCOUNT_ACTIONS = frozenset(
+        {
+            "credentials_list",
+            "linked_link_url",
+            "linked_list",
+            "linked_unlink",
+            "sessions_list",
+            "sessions_revoke_one",
+        }
+    )
+
+    def test_default_viewset_carries_no_account_actions(self):
+        actions = {
+            a.__name__ for a in UserModelOpenIDConnectViewset.get_extra_actions()
+        }
+        self.assertEqual(actions & self.ACCOUNT_ACTIONS, set())
+
+    def test_mixing_the_mixin_in_adds_them(self):
+        actions = {a.__name__ for a in KeycloakOpenIDConnectViewset.get_extra_actions()}
+        self.assertTrue(self.ACCOUNT_ACTIONS.issubset(actions))
+
+    def test_default_urlconf_has_no_account_routes(self):
+        """Not a 503 — the paths simply do not resolve."""
+        for path in (
+            "/oidc/example/sessions",
+            "/oidc/example/linked-accounts",
+            "/oidc/example/credentials",
+        ):
+            with self.subTest(path=path):
+                with self.assertRaises(Resolver404):
+                    resolve(path)
+
+
+@override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+class TestTokenStashIsOptIn(TestCase):
+    """``callback`` only keeps the access/refresh pair for a viewset that
+    says it needs them -- a stashed refresh token is credential material at
+    rest, so a deployment that never calls the IdP on the user's behalf
+    should not accumulate one."""
+
+    TOKENS = {
+        "id_token": "idp-id-token",
+        "access_token": "idp-access-token",
+        "refresh_token": "idp-refresh-token",
+    }
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _run_callback(self, viewset_class):
+        """Drive a full auth-code callback and return the resulting session."""
+        view = viewset_class.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value=dict(self.TOKENS),
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value={
+                    "name": "Stash User",
+                    "preferred_username": "stash@example.com",
+                    "given_name": "Stash",
+                    "family_name": "User",
+                    "email": "stash@example.com",
+                },
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = {}
+            response = view(request, auth_server="default")
+        self.assertEqual(response.status_code, 302)
+        return request.session
+
+    def test_default_viewset_does_not_stash(self):
+        session = self._run_callback(UserModelOpenIDConnectViewset)
+        self.assertNotIn("oidc_access_token:default", session)
+        self.assertNotIn("oidc_refresh_token:default", session)
+        # The id_token is still kept -- logout replays it as id_token_hint.
+        self.assertEqual(session.get("oidc_id_token:default"), "idp-id-token")
+
+    def test_the_account_proxy_opts_in(self):
+        session = self._run_callback(KeycloakOpenIDConnectViewset)
+        self.assertEqual(session["oidc_access_token:default"], "idp-access-token")
+        self.assertEqual(session["oidc_refresh_token:default"], "idp-refresh-token")
+
+
+class TestForgedHostHeader(TestCase):
+    """A Host header ALLOWED_HOSTS rejects must not crash the origin check.
+
+    ``_trusted_spa_hosts`` adds ``request.get_host()`` as a convenience for
+    same-origin deployments, and that call raises ``DisallowedHost``. The
+    configured allowlist is the static trust root, so it has to stand alone.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.perm = IsCsrfSafeAccountRequest()
+        self.view = SimpleNamespace(kwargs={"auth_server": "default"})
+        self.header_kwarg = {
+            "HTTP_" + get_account_request_header().upper().replace("-", "_"): "1"
+        }
+
+    @override_settings(
+        ALLOWED_HOSTS=["real.example.com"],
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "LOGIN_REDIRECT_ALLOWED_HOSTS": ["spa.example.com"],
+            },
+        },
+    )
+    def test_forged_host_falls_back_to_the_configured_allowlist(self):
+        """Denied on its merits (403), not by an escaping DisallowedHost."""
+        forged = self.factory.post(
+            "/",
+            HTTP_HOST="attacker.example.com",
+            HTTP_ORIGIN="https://evil.example.com",
+            **self.header_kwarg,
+        )
+        self.assertFalse(self.perm.has_permission(forged, self.view))
+
+        # ...and a genuinely configured origin still passes, so the fallback
+        # narrows the trust set rather than emptying it.
+        configured = self.factory.post(
+            "/",
+            HTTP_HOST="attacker.example.com",
+            HTTP_ORIGIN="https://spa.example.com",
+            **self.header_kwarg,
+        )
+        self.assertTrue(self.perm.has_permission(configured, self.view))
+
+
+class TestSessionIdPathTraversal(TestCase):
+    """``session_id`` is interpolated into the upstream URL, and ``requests``
+    resolves dot segments before sending — so ``..`` would escape
+    ``/sessions/`` and issue the DELETE against the Keycloak account root.
+    The route pattern allows dots, so the action has to reject them.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_dot_segment_session_id_is_rejected_before_any_upstream_call(self):
+        view = KeycloakOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
+        for session_id in ("..", ".", "..%2f.."):
+            with self.subTest(session_id=session_id):
+                request = self.factory.delete("/")
+                request.session = {"oidc_access_token:default": "t"}
+                with patch("oidc.client.requests.request") as mock_request:
+                    response = view(
+                        request, auth_server="default", session_id=session_id
+                    )
+                self.assertEqual(response.status_code, 400)
+                # The point of the guard: Keycloak is never contacted.
+                mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_a_real_session_id_still_reaches_the_expected_url(self):
+        """The guard must not narrow the endpoint to uselessness."""
+        view = KeycloakOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token:default": "t"}
+        mock_response = MagicMock(status_code=204, content=b"")
+        with patch(
+            "oidc.client.requests.request", return_value=mock_response
+        ) as mock_request:
+            response = view(
+                request,
+                auth_server="default",
+                session_id="6b1f2c3d-4e5a-6789-0abc-def012345678",
+            )
+        self.assertEqual(response.status_code, 204)
+        args, _kwargs = mock_request.call_args
+        self.assertEqual(
+            args[1],
+            "https://idp.example.com/realms/r/account/sessions/"
+            "6b1f2c3d-4e5a-6789-0abc-def012345678",
+        )
+
+
+class TestMisconfigurationIsNotAnOutage(TestCase):
+    """An endpoint we never configured is our gap, not the IdP being down.
+
+    Both ``ACCOUNT_ENDPOINT`` and ``TOKEN_ENDPOINT`` are guarded the same way
+    and surface as 503, so nobody is sent to check on a healthy Keycloak.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+                "TOKEN_ENDPOINT": "",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_unset_token_endpoint_is_503_not_502(self):
+        """Reached only on the refresh path, so drive a 401 to get there."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {
+            "oidc_access_token:default": "expired.access.token",
+            "oidc_refresh_token:default": "stashed.refresh.token",
+        }
+
+        unauthorized = MagicMock(status_code=401, content=b"{}")
+        unauthorized.json.return_value = {"error": "invalid_token"}
+
+        with (
+            patch("oidc.client.requests.request", return_value=unauthorized),
+            patch("oidc.client.requests.post") as mock_post,
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 503)
+        # The guard fires before the request is built, so no bogus URL is
+        # handed to requests and no call leaves the process.
+        mock_post.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_a_non_json_token_response_is_502_not_503(self):
+        """``requests`` raises ``JSONDecodeError`` for a non-JSON body, and it
+        subclasses both ``ValueError`` and ``RequestException``. Catching bare
+        ``ValueError`` for the config case would swallow it and blame our own
+        settings for what is a proxy or WAF returning an HTML interstitial."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {
+            "oidc_access_token:default": "expired.access.token",
+            "oidc_refresh_token:default": "stashed.refresh.token",
+        }
+
+        unauthorized = MagicMock(status_code=401, content=b"{}")
+        unauthorized.json.return_value = {"error": "invalid_token"}
+        html_body = MagicMock(status_code=200)
+        html_body.raise_for_status = MagicMock()
+        html_body.json.side_effect = requests.exceptions.JSONDecodeError(
+            "Expecting value", "<html>", 0
+        )
+
+        with (
+            patch("oidc.client.requests.request", return_value=unauthorized),
+            patch("oidc.client.requests.post", return_value=html_body),
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 502)
+
+    def test_refresh_names_the_setting_it_is_missing(self):
+        """The message has to say which setting, or the 503 is a scavenger
+        hunt across every configured auth server."""
+        client = OpenIDClient("default")
+        client.token_endpoint = ""
+        with self.assertRaises(ValueError) as ctx:
+            client.refresh_access_token("some.refresh.token")
+        self.assertIn("TOKEN_ENDPOINT", str(ctx.exception))
+        self.assertIn("default", str(ctx.exception))
+
+
+@override_settings(ROOT_URLCONF="tests.keycloak_urls")
+class TestProxyErrorsAreAlwaysJson(TestCase):
+    """These actions declare ``renderer_classes=[JSONRenderer]``, and the SPA
+    reads the message out of ``body.error``. An error that answers in HTML
+    degrades to a bare status code on the client, so every failure mode has
+    to stay JSON."""
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_unknown_auth_server_answers_json(self):
+        response = self.client.get("/oidc/nosuchserver/sessions")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.headers["Content-Type"], "application/json")
+        self.assertIn("error", response.json())
+
+
+#: A second configured provider. The route picks the provider, so anything
+#: the session stores globally is reachable from every provider's URL.
+_TWO_PROVIDERS = {
+    "default": {
+        **OPENID_CONNECT_AUTH_SERVERS["default"],
+        "ACCOUNT_ENDPOINT": "https://idp-a.example.com/realms/a/account",
+    },
+    "other": {
+        **OPENID_CONNECT_AUTH_SERVERS["default"],
+        "ACCOUNT_ENDPOINT": "https://idp-b.example.com/realms/b/account",
+        "TOKEN_ENDPOINT": "https://idp-b.example.com/realms/b/token",
+        "END_SESSION_ENDPOINT": "https://idp-b.example.com/realms/b/logout",
+    },
+}
+
+
+@override_settings(
+    OPENID_CONNECT_AUTH_SERVERS=_TWO_PROVIDERS,
+    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+)
+class TestTokensAreScopedToAuthServer(TestCase):
+    """Tokens belong to the provider that issued them.
+
+    ``OPENID_CONNECT_AUTH_SERVERS`` is a keyed dict and every key gets its
+    own route, so a session that stores tokens under one global key lets a
+    request to provider B replay provider A's credentials against B's
+    endpoints. Nothing here is about a hostile ``auth_server`` value --
+    ``_get_client`` already 400s on unknown names -- it is about one
+    configured provider receiving another's tokens.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _session_for(self, auth_server):
+        """A session as ``callback`` leaves it after login to ``auth_server``."""
+        view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value={
+                    "id_token": f"{auth_server}-id-token",
+                    "access_token": f"{auth_server}-access-token",
+                    "refresh_token": f"{auth_server}-refresh-token",
+                },
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value={
+                    "name": "Scoped User",
+                    "preferred_username": "scoped@example.com",
+                    "given_name": "Scoped",
+                    "family_name": "User",
+                    "email": "scoped@example.com",
+                },
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = {}
+            response = view(request, auth_server=auth_server)
+        self.assertEqual(response.status_code, 302)
+        return request.session
+
+    def test_callback_does_not_stash_tokens_under_a_global_key(self):
+        """The stash has to name its provider, or every other provider's
+        route can read it."""
+        session = self._session_for("default")
+
+        self.assertNotIn("oidc_access_token", session)
+        self.assertNotIn("oidc_refresh_token", session)
+        self.assertNotIn("oidc_id_token", session)
+        # ...but the tokens are still there, under a provider-scoped name.
+        self.assertIn("default-access-token", session.values())
+        self.assertIn("default-refresh-token", session.values())
+
+    def test_another_providers_route_cannot_spend_this_providers_access_token(self):
+        """The access-token leak: B's account endpoint must never receive a
+        token A issued."""
+        session = self._session_for("default")
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = session
+
+        # A well-formed response the call must never reach: a bare MagicMock
+        # would blow up inside DRF on a regression instead of failing here.
+        unreached = MagicMock(status_code=200, content=b"[]")
+        unreached.json.return_value = []
+
+        with patch(
+            "oidc.client.requests.request", return_value=unreached
+        ) as mock_request:
+            response = view(request, auth_server="other")
+
+        self.assertEqual(response.status_code, 401)
+        mock_request.assert_not_called()
+
+    def test_another_providers_route_cannot_replay_the_refresh_token(self):
+        """The amplification, and the worse half of the bug.
+
+        A foreign access token draws a 401 from B, and the retry path treats
+        any 401 as "expired -- refresh it". Unscoped, that POSTs A's
+        *long-lived* refresh token to B's token endpoint, so the failure
+        mode leaks more than the request did.
+        """
+        session = self._session_for("default")
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = session
+
+        rejected = MagicMock(status_code=401, content=b"{}")
+        rejected.json.return_value = {"error": "invalid_token"}
+
+        with (
+            patch("oidc.client.requests.request", return_value=rejected),
+            patch("oidc.client.requests.post") as mock_post,
+        ):
+            response = view(request, auth_server="other")
+
+        self.assertEqual(response.status_code, 401)
+        mock_post.assert_not_called()
+
+    def test_logout_does_not_replay_another_providers_id_token(self):
+        """id_tokens carry sub/email/name, so handing A's to B's end-session
+        endpoint as ``id_token_hint`` discloses the user to the wrong IdP."""
+        session = self._session_for("default")
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "logout"})
+        request = self.factory.get("/")
+        request.session = session
+
+        response = view(request, auth_server="other")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn("id_token_hint", response.url)
+        self.assertNotIn("default-id-token", response.url)
+
+    def test_the_owning_provider_still_works(self):
+        """The guard must not break the ordinary single-provider path."""
+        session = self._session_for("default")
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = session
+
+        ok = MagicMock(status_code=200, content=b"[]")
+        ok.json.return_value = []
+
+        with patch("oidc.client.requests.request", return_value=ok) as mock_request:
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        sent_headers = mock_request.call_args.kwargs["headers"]
+        self.assertEqual(sent_headers["Authorization"], "Bearer default-access-token")
+
+
+@override_settings(
+    OPENID_CONNECT_AUTH_SERVERS=_TWO_PROVIDERS,
+    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+)
+class TestLogoutClearsStashedTokens(TestCase):
+    """Logging out has to drop the whole token stash, not just the hint.
+
+    The end-session response is a *redirect*: the user may never complete
+    it (closed tab, declined confirm screen, unreachable IdP), so the pop
+    is the only point in the flow we control. Leaving the pair behind
+    keeps a logged-out session spending credentials at the account proxy,
+    and leaves a refresh token at rest in the session store -- the same
+    thing ``stash_oidc_tokens`` exists to avoid for viewsets that never
+    need one.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _logged_in_session(self, auth_server="default"):
+        return {
+            token_session_key(ID_TOKEN_SESSION_KEY, auth_server): "ey.id.token",
+            token_session_key(ACCESS_TOKEN_SESSION_KEY, auth_server): "stashed.access",
+            token_session_key(
+                REFRESH_TOKEN_SESSION_KEY, auth_server
+            ): "stashed.refresh",
+        }
+
+    def test_logout_drops_the_access_and_refresh_tokens(self):
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "logout"})
+        request = self.factory.get("/")
+        request.session = self._logged_in_session()
+
+        response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn("oidc_access_token:default", request.session)
+        self.assertNotIn("oidc_refresh_token:default", request.session)
+        self.assertNotIn("oidc_id_token:default", request.session)
+
+    def test_logout_does_not_flush_unrelated_session_data(self):
+        """Targeted removal, not a flush -- the session may be carrying
+        state that has nothing to do with this provider."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "logout"})
+        request = self.factory.get("/")
+        request.session = {**self._logged_in_session(), "unrelated": "keep"}
+
+        view(request, auth_server="default")
+
+        self.assertEqual(request.session.get("unrelated"), "keep")
+
+    def test_logout_leaves_another_providers_tokens_alone(self):
+        """Logout is per-provider; ending the session at A must not sign
+        the user out of B."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "logout"})
+        request = self.factory.get("/")
+        request.session = {
+            **self._logged_in_session("default"),
+            **self._logged_in_session("other"),
+        }
+
+        view(request, auth_server="default")
+
+        self.assertEqual(
+            request.session.get("oidc_access_token:other"), "stashed.access"
+        )
+        self.assertEqual(
+            request.session.get("oidc_refresh_token:other"), "stashed.refresh"
+        )
+
+    def test_the_account_proxy_stops_working_after_logout(self):
+        """The point of the whole thing: a logged-out session must not be
+        able to keep calling Keycloak as the user."""
+        logout_view = KeycloakOpenIDConnectViewset.as_view({"get": "logout"})
+        request = self.factory.get("/")
+        request.session = self._logged_in_session()
+        logout_view(request, auth_server="default")
+
+        proxy_view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        proxy_request = self.factory.get("/")
+        proxy_request.session = request.session
+
+        # See the note in TestTokensAreScopedToAuthServer: a well-formed
+        # response keeps a regression failing on assert_not_called rather
+        # than as a TypeError deep in DRF.
+        unreached = MagicMock(status_code=200, content=b"[]")
+        unreached.json.return_value = []
+
+        with patch(
+            "oidc.client.requests.request", return_value=unreached
+        ) as mock_request:
+            response = proxy_view(proxy_request, auth_server="default")
+
+        self.assertEqual(response.status_code, 401)
+        mock_request.assert_not_called()
+
+
+@override_settings(
+    OPENID_CONNECT_AUTH_SERVERS={
+        **OPENID_CONNECT_AUTH_SERVERS,
+        "default": {
+            **OPENID_CONNECT_AUTH_SERVERS["default"],
+            "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+        },
+    },
+    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+)
+class TestProviderAliasCharset(TestCase):
+    """Keycloak accepts dots and mixed case in an identity-provider alias.
+
+    Hostname-shaped aliases (``idp.acme.com``) are ordinary in the wild --
+    Keycloak builds ``brokerUserId`` as ``alias + "." + federatedUserId``,
+    which is what keycloak/keycloak#42209 is about -- so an allowlist
+    without ``.`` silently 400s a correctly configured realm's IdP.
+
+    The dot still cannot be allowed unconditionally: these values are
+    interpolated into the upstream URL and ``requests`` resolves dot
+    segments before sending, so an alias of exactly ``.`` or ``..`` would
+    walk out of ``/linked-accounts/``. Since ``/`` is outside the charset
+    there are no interior segments to consider, so rejecting those two
+    exact values is the whole of it.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _unlink(self, provider):
+        view = KeycloakOpenIDConnectViewset.as_view({"delete": "linked_unlink"})
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+        upstream = MagicMock(status_code=204, content=b"")
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            response = view(request, auth_server="default", provider=provider)
+        return response, mock_request
+
+    def _link_url(self, provider):
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_link_url"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token:default": "stashed.access.token"}
+        upstream = MagicMock(status_code=200, content=b"{}")
+        upstream.json.return_value = {}
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            response = view(request, auth_server="default", provider=provider)
+        return response, mock_request
+
+    def test_hostname_shaped_alias_is_accepted(self):
+        response, mock_request = self._unlink("idp.acme.com")
+
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertTrue(args[1].endswith("/linked-accounts/idp.acme.com"))
+
+    def test_mixed_case_alias_is_accepted(self):
+        """The session-id charset already allows uppercase; the alias one
+        did not, so ``MyIdP`` was rejected for the same wrong reason."""
+        response, mock_request = self._unlink("MyIdP")
+
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertTrue(args[1].endswith("/linked-accounts/MyIdP"))
+
+    def test_link_url_accepts_the_same_charset(self):
+        """Both alias-taking actions validate identically -- one widened
+        without the other is a confusing half-fix."""
+        response, mock_request = self._link_url("idp.acme.com")
+
+        self.assertEqual(response.status_code, 200)
+        args, _ = mock_request.call_args
+        self.assertTrue(args[1].endswith("/linked-accounts/idp.acme.com"))
+
+    def test_bare_dot_segments_are_still_rejected(self):
+        """The reason the dot was excluded in the first place. These must
+        never reach Keycloak: ``requests`` would normalise them away and
+        issue the DELETE against the account root."""
+        for alias in ("..", "."):
+            with self.subTest(alias=alias):
+                response, mock_request = self._unlink(alias)
+                self.assertEqual(response.status_code, 400)
+                mock_request.assert_not_called()
+
+                response, mock_request = self._link_url(alias)
+                self.assertEqual(response.status_code, 400)
+                mock_request.assert_not_called()
+
+    def test_traversal_and_separators_are_still_rejected(self):
+        """A dot in the charset must not become a dot *sequence* with a
+        separator: ``/`` stays out, so no interior segment can form."""
+        for alias in ("../etc/passwd", "..%2f..", "a/b", "", "with space"):
+            with self.subTest(alias=alias):
+                response, mock_request = self._unlink(alias)
+                self.assertEqual(response.status_code, 400)
+                mock_request.assert_not_called()
+
+    def test_an_alias_that_merely_contains_dots_is_fine(self):
+        """``..`` is only dangerous as a whole segment -- these are not."""
+        for alias in ("a..b", "..leading", "trailing.."):
+            with self.subTest(alias=alias):
+                response, _ = self._unlink(alias)
+                self.assertEqual(response.status_code, 204)
+
+
+class TestTokensAreNotStashedOnRefusedLogin(TestCase):
+    """The IdP accepting a user is not the platform accepting them.
+
+    Between the token exchange and a successful login the callback has
+    several 400/401 exits -- no local user under ``AUTO_CREATE_USER=False``,
+    required claims missing, validation errors. Stashing the tokens above
+    those exits leaves every one of them with a session the account proxy
+    treats as signed in, so a caller the deployment just refused can still
+    list and revoke Keycloak sessions, unlink IdPs and read credentials.
+    """
+
+    TOKENS = {
+        "id_token": "idp-id-token",
+        "access_token": "idp-access-token",
+        "refresh_token": "idp-refresh-token",
+    }
+
+    FULL_CLAIMS = {
+        "given_name": "Refused",
+        "family_name": "User",
+        "email": "refused@example.com",
+        "preferred_username": "refused",
+    }
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _run_callback(self, claims):
+        """Drive a full auth-code callback; return (response, session)."""
+        view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value=dict(self.TOKENS),
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value=claims,
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = {}
+            response = view(request, auth_server="default")
+        return response, request.session
+
+    def _assert_no_tokens(self, session):
+        for base_key in (
+            ACCESS_TOKEN_SESSION_KEY,
+            REFRESH_TOKEN_SESSION_KEY,
+            ID_TOKEN_SESSION_KEY,
+        ):
+            self.assertNotIn(token_session_key(base_key, "default"), session)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "AUTO_CREATE_USER": False,
+        }
+    )
+    def test_nothing_stashed_when_the_deployment_refuses_to_provision(self):
+        """AUTO_CREATE_USER=False is an access-control gate. A caller it
+        turns away must not walk off with a working proxy session."""
+        response, session = self._run_callback(self.FULL_CLAIMS)
+
+        self.assertEqual(response.status_code, 401)
+        self._assert_no_tokens(session)
+
+    def test_nothing_stashed_when_required_claims_are_missing(self):
+        """Email-only claims: present so no user-info round-trip happens,
+        while first_name stays missing whatever the fallbacks do --
+        ``_clean_user_data`` backfills it from last_name and username from
+        email, but there is no last_name here -- so this is the hard 400
+        exit, not the username form."""
+        response, session = self._run_callback({"email": "refused@example.com"})
+
+        self.assertEqual(response.status_code, 400)
+        self._assert_no_tokens(session)
+
+    def test_tokens_are_still_stashed_on_a_successful_login(self):
+        """The guard: moving the stash must not stop it happening."""
+        response, session = self._run_callback(self.FULL_CLAIMS)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            session[token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")],
+            "idp-access-token",
+        )
+        self.assertEqual(
+            session[token_session_key(REFRESH_TOKEN_SESSION_KEY, "default")],
+            "idp-refresh-token",
+        )
+        self.assertEqual(
+            session[token_session_key(ID_TOKEN_SESSION_KEY, "default")],
+            "idp-id-token",
+        )
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "AUTO_CREATE_USER": False,
+        },
+    )
+    def test_the_account_proxy_refuses_a_session_from_a_refused_callback(self):
+        """What the stash actually buys an unprovisioned caller, end to end."""
+        response, session = self._run_callback(self.FULL_CLAIMS)
+        self.assertEqual(response.status_code, 401)
+
+        proxy_view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        proxy_request = self.factory.get("/")
+        proxy_request.session = session
+
+        unreached = MagicMock(status_code=200, content=b"[]")
+        unreached.json.return_value = []
+        with patch(
+            "oidc.client.requests.request", return_value=unreached
+        ) as mock_request:
+            proxy_response = proxy_view(proxy_request, auth_server="default")
+
+        self.assertEqual(proxy_response.status_code, 401)
+        mock_request.assert_not_called()
+
+    def test_username_form_round_trip_carries_the_token_pair_through_pending(self):
+        """The flow pending slots exist to serve beyond refusal-gating.
+
+        Only the first callback holds the access/refresh pair -- the
+        username form re-POSTs just the id_token -- so the pair rides in
+        the session as pending across the round trip. It must be invisible
+        to the proxy while the form is up (login not yet accepted) and
+        active once the resubmit succeeds.
+        """
+        # No preferred_username claim at all: with USE_EMAIL_USERNAME off
+        # (the tests/settings.py default) that leaves exactly {username}
+        # missing, which is the 200 username-form path.
+        claims = {
+            "given_name": "Pend",
+            "family_name": "User",
+            "email": "pend@example.com",
+        }
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+            return_value=claims,
+        ):
+            view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+            with patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value=dict(self.TOKENS),
+            ):
+                first = self.factory.post("/", data={"code": "auth-code"})
+                first.session = {}
+                first_response = view(first, auth_server="default")
+
+            # The username form is up: not signed in yet.
+            self.assertEqual(first_response.status_code, 200)
+            self.assertNotIn(
+                token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"),
+                first.session,
+            )
+
+            # The form re-POSTs with only the id_token; same session.
+            resubmit = self.factory.post(
+                "/?code=stale-code&state=stale-state",
+                data={
+                    "id_token": "idp-id-token",
+                    "username": "pend_chosen",
+                    USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+                },
+            )
+            resubmit.session = first.session
+            resubmit_response = view(resubmit, auth_server="default")
+
+        self.assertEqual(resubmit_response.status_code, 302)
+        self.assertEqual(
+            resubmit.session[token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")],
+            "idp-access-token",
+        )
+        self.assertEqual(
+            resubmit.session[token_session_key(REFRESH_TOKEN_SESSION_KEY, "default")],
+            "idp-refresh-token",
+        )
+
+
+@override_settings(ROOT_URLCONF="tests.keycloak_urls")
+class TestReadsAreOriginGated(TestCase):
+    """Safe methods enforce the Origin allowlist too — header not required.
+
+    The way a cross-origin page *reads* one of these listings is a
+    credentialed CORS fetch against a deployment whose CORS reflects
+    arbitrary origins — and that fetch always carries ``Origin``. Checking
+    it server-side closes the leak the old docstring could only warn about.
+
+    The custom header stays a write-only requirement: markup GETs
+    (``<img>``, ``<script>``) cannot read JSON responses anyway, so a
+    header check on reads adds nothing the Origin check does not — and the
+    SPA deliberately omits the header on GET, with a client-side test
+    pinning exactly that.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.perm = IsCsrfSafeAccountRequest()
+        self.view = SimpleNamespace(kwargs={"auth_server": "default"})
+
+    def test_get_from_an_untrusted_origin_is_denied(self):
+        request = self.factory.get("/", HTTP_ORIGIN="https://evil.example")
+        self.assertFalse(self.perm.has_permission(request, self.view))
+
+    def test_get_without_origin_is_allowed(self):
+        """Same-origin GETs (navigation, same-origin fetch) omit Origin."""
+        self.assertTrue(self.perm.has_permission(self.factory.get("/"), self.view))
+
+    def test_get_from_own_host_is_allowed(self):
+        request = self.factory.get("/", HTTP_ORIGIN="http://testserver")
+        self.assertTrue(self.perm.has_permission(request, self.view))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "LOGIN_REDIRECT_ALLOWED_HOSTS": ["app.example.com"],
+            },
+        }
+    )
+    def test_get_from_the_allowlisted_spa_needs_no_header(self):
+        """Pins the read contract the SPA relies on: trusted origin,
+        no ``X-Ona-Account-Request``, still allowed."""
+        request = self.factory.get("/", HTTP_ORIGIN="https://app.example.com")
+        self.assertTrue(self.perm.has_permission(request, self.view))
+
+    def test_writes_still_need_the_header_even_from_a_trusted_origin(self):
+        """The origin gate joining the safe path must not relax the write
+        path: same-origin without the header stays refused."""
+        request = self.factory.post("/", HTTP_ORIGIN="http://testserver")
+        self.assertFalse(self.perm.has_permission(request, self.view))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_a_cross_origin_read_never_reaches_keycloak(self):
+        """End to end: even with hostile CORS reflecting the attacker's
+        origin, the listing is never fetched, so there is nothing for the
+        browser to hand over.
+
+        as_view is given the permission explicitly: calling an @action
+        method this way bypasses the decorator's kwargs (the router applies
+        those), which would silently test AllowAny instead."""
+        view = KeycloakOpenIDConnectViewset.as_view(
+            {"get": "linked_list"},
+            authentication_classes=[],
+            permission_classes=[IsCsrfSafeAccountRequest],
+        )
+        request = self.factory.get("/", HTTP_ORIGIN="https://evil.example")
+        request.session = {"oidc_access_token:default": "t"}
+
+        unreached = MagicMock(status_code=200, content=b"[]")
+        unreached.json.return_value = []
+        with patch(
+            "oidc.client.requests.request", return_value=unreached
+        ) as mock_request:
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 403)
+        mock_request.assert_not_called()
+
+
+@override_settings(
+    OPENID_CONNECT_AUTH_SERVERS={
+        **OPENID_CONNECT_AUTH_SERVERS,
+        "default": {
+            **OPENID_CONNECT_AUTH_SERVERS["default"],
+            "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+        },
+    },
+    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+)
+class TestPendingTokensBelongToOneFlow(TestCase):
+    """Pending slots are per-provider, but a session can run two logins.
+
+    Two tabs, one Django session: only the tab that reaches the username
+    form keeps a pending access/refresh pair, and the form re-POST carries
+    just an id_token. If promotion pairs that id_token with whatever pair
+    happens to be pending, the SPA ends up signed in as one identity while
+    the account proxy authenticates to Keycloak as another.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _callback(self, session, claims, tokens):
+        view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value=dict(tokens),
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value=claims,
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = session
+            response = view(request, auth_server="default")
+        return response
+
+    def _resubmit(self, session, claims, id_token, username):
+        view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+            return_value=claims,
+        ):
+            request = self.factory.post(
+                "/",
+                data={
+                    "id_token": id_token,
+                    "username": username,
+                    USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+                },
+            )
+            request.session = session
+            response = view(request, auth_server="default")
+        return response
+
+    def test_an_interleaved_flow_cannot_donate_its_token_pair(self):
+        """Both tabs must reach the *username form*, not just one.
+
+        Only the form exit parks a pair, so an interleaving where the second
+        tab takes a hard refusal parks nothing and there is no mismatched
+        pair to reject — such a test passes with the owner check deleted.
+        Here tab B parks over tab A's slots, so A's resubmit is handed a
+        pair belonging to B and must refuse it.
+        """
+        session = {}
+        x_claims = {
+            "given_name": "Ex",
+            "family_name": "User",
+            "email": "x@example.com",
+        }
+        y_claims = {
+            "given_name": "Why",
+            "family_name": "User",
+            "email": "y@example.com",
+        }
+
+        # Tab A: identity X. Derived username "x" is under 3 chars -> form.
+        first = self._callback(
+            session,
+            x_claims,
+            {
+                "id_token": "id-token-X",
+                "access_token": "access-X",
+                "refresh_token": "refresh-X",
+            },
+        )
+        self.assertEqual(first.status_code, 200)
+
+        # Tab B: identity Y, same session, also lands on the form and parks
+        # over A's slots.
+        second = self._callback(
+            session,
+            y_claims,
+            {
+                "id_token": "id-token-Y",
+                "access_token": "access-Y",
+                "refresh_token": "refresh-Y",
+            },
+        )
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(
+            session.get(pending_token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")),
+            "access-Y",
+            "tab B should have parked over tab A -- otherwise this test proves nothing",
+        )
+
+        # Tab A completes. Carries only X's id_token; the parked pair is B's.
+        done = self._resubmit(session, x_claims, "id-token-X", "ex_chosen")
+        self.assertEqual(done.status_code, 302)
+
+        # Signed in as X, so the proxy must not hold Y's credentials. Assert
+        # the slots are absent outright, not merely "not Y's".
+        self.assertEqual(
+            session.get(token_session_key(ID_TOKEN_SESSION_KEY, "default")),
+            "id-token-X",
+        )
+        self.assertNotIn(
+            token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"), session
+        )
+        self.assertNotIn(
+            token_session_key(REFRESH_TOKEN_SESSION_KEY, "default"), session
+        )
+
+    def test_a_flow_without_a_refresh_token_cannot_inherit_one(self):
+        """The park must be atomic. If a second flow's token response has no
+        refresh token, skipping that slot would leave the first flow's
+        refresh token behind under the *second* flow's owner tag — waving a
+        mispaired credential through the very check meant to catch it."""
+        session = {}
+        x_claims = {
+            "given_name": "Ex",
+            "family_name": "User",
+            "email": "x@example.com",
+        }
+        y_claims = {
+            "given_name": "Why",
+            "family_name": "User",
+            "email": "y@example.com",
+        }
+
+        self._callback(
+            session,
+            x_claims,
+            {
+                "id_token": "id-token-X",
+                "access_token": "access-X",
+                "refresh_token": "refresh-X",
+            },
+        )
+        # Tab B: access token but no refresh token.
+        self._callback(
+            session,
+            y_claims,
+            {"id_token": "id-token-Y", "access_token": "access-Y"},
+        )
+
+        done = self._resubmit(session, y_claims, "id-token-Y", "why_chosen")
+        self.assertEqual(done.status_code, 302)
+        self.assertNotIn(
+            token_session_key(REFRESH_TOKEN_SESSION_KEY, "default"),
+            session,
+            "flow Y inherited flow X's refresh token",
+        )
+
+    def test_a_dropped_pair_does_not_leave_an_earlier_logins_pair_active(self):
+        """Refusing a mismatched pair must also clear whatever a previous
+        login left in the active slots, or the new id_token ends up beside
+        the old pair — the same split, reached from the other side."""
+        session = {}
+        z_claims = {
+            "given_name": "Zed",
+            "family_name": "User",
+            "email": "zed@example.com",
+        }
+        # A completed login leaves an active pair behind.
+        self._callback(
+            session,
+            z_claims,
+            {
+                "id_token": "id-token-Z",
+                "access_token": "access-Z",
+                "refresh_token": "refresh-Z",
+            },
+        )
+        self.assertEqual(
+            session[token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")], "access-Z"
+        )
+
+        # Two interleaved form flows; the second parks over the first.
+        x_claims = {
+            "given_name": "Ex",
+            "family_name": "User",
+            "email": "x@example.com",
+        }
+        y_claims = {
+            "given_name": "Why",
+            "family_name": "User",
+            "email": "y@example.com",
+        }
+        self._callback(
+            session,
+            x_claims,
+            {
+                "id_token": "id-token-X",
+                "access_token": "access-X",
+                "refresh_token": "refresh-X",
+            },
+        )
+        self._callback(
+            session,
+            y_claims,
+            {
+                "id_token": "id-token-Y",
+                "access_token": "access-Y",
+                "refresh_token": "refresh-Y",
+            },
+        )
+
+        done = self._resubmit(session, x_claims, "id-token-X", "ex_chosen")
+        self.assertEqual(done.status_code, 302)
+        self.assertNotIn(
+            token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"),
+            session,
+            "Z's pair survived beside X's id_token",
+        )
+
+    def test_an_abandoned_form_does_not_leave_a_pair_parked_forever(self):
+        """Nothing else clears a parked pair for a login that was never
+        finished, so the next success in the session has to."""
+        session = {}
+        self._callback(
+            session,
+            {"given_name": "Ex", "family_name": "User", "email": "x@example.com"},
+            {
+                "id_token": "id-token-X",
+                "access_token": "access-X",
+                "refresh_token": "refresh-X",
+            },
+        )
+        self.assertIn(
+            pending_token_session_key(REFRESH_TOKEN_SESSION_KEY, "default"), session
+        )
+
+        # A different, complete login in the same session.
+        self._callback(
+            session,
+            {
+                "given_name": "Solo",
+                "family_name": "User",
+                "email": "solo@example.com",
+            },
+            {
+                "id_token": "id-token-S",
+                "access_token": "access-S",
+                "refresh_token": "refresh-S",
+            },
+        )
+
+        for base_key in (
+            ID_TOKEN_SESSION_KEY,
+            ACCESS_TOKEN_SESSION_KEY,
+            REFRESH_TOKEN_SESSION_KEY,
+        ):
+            self.assertNotIn(
+                pending_token_session_key(base_key, "default"),
+                session,
+                "abandoned pair still parked",
+            )
+
+    def test_a_hard_refusal_leaves_no_credentials_at_rest(self):
+        """A refused caller never logs out, so nothing else will ever clear
+        their stash. It must not be written in the first place."""
+        session = {}
+        response = self._callback(
+            session,
+            {"email": "y@example.com"},
+            {
+                "id_token": "id-token-Y",
+                "access_token": "access-Y",
+                "refresh_token": "refresh-Y",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            [
+                v
+                for v in session.values()
+                if "access-Y" in str(v) or "refresh-Y" in str(v)
+            ],
+            [],
+            f"refresh/access token left at rest in session: {session}",
+        )
+
+    def test_the_ordinary_form_round_trip_still_works(self):
+        """Guard: the flow pending slots exist for must keep working."""
+        session = {}
+        # A one-character local part: USE_EMAIL_USERNAME derives "s", which
+        # fails the 3-char username regex, so only {username} is missing --
+        # the form exit rather than a straight success.
+        claims = {
+            "given_name": "Solo",
+            "family_name": "User",
+            "email": "s@example.com",
+        }
+        first = self._callback(
+            session,
+            claims,
+            {
+                "id_token": "id-token-S",
+                "access_token": "access-S",
+                "refresh_token": "refresh-S",
+            },
+        )
+        self.assertEqual(first.status_code, 200)
+
+        done = self._resubmit(session, claims, "id-token-S", "solo_chosen")
+        self.assertEqual(done.status_code, 302)
+        self.assertEqual(
+            session[token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")],
+            "access-S",
+        )
+        self.assertEqual(
+            session[token_session_key(REFRESH_TOKEN_SESSION_KEY, "default")],
+            "refresh-S",
+        )
+
+
+class TestProviderAliasAnchoring(TestCase):
+    """``$`` also matches before a trailing newline, so an alias validator
+    anchored with ``$`` does not actually pin the whole string."""
+
+    def test_a_trailing_newline_cannot_smuggle_a_dot_segment(self):
+        from oidc.keycloak import _is_valid_provider_alias
+
+        for alias in ("..\n", ".\n", "google\n"):
+            with self.subTest(alias=alias):
+                self.assertFalse(_is_valid_provider_alias(alias))
+
+    def test_ordinary_aliases_still_pass(self):
+        from oidc.keycloak import _is_valid_provider_alias
+
+        for alias in ("google", "idp.acme.com", "MyIdP", "a..b"):
+            with self.subTest(alias=alias):
+                self.assertTrue(_is_valid_provider_alias(alias))
+
+
+@override_settings(
+    OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
+    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+)
+class TestLogoutClearsPreNamespacingTokens(TestCase):
+    """A session established before the per-provider rename holds bare
+    ``oidc_id_token`` etc. Nothing reads those any more, but only
+    ``logout`` can remove them -- the session is flushed just under
+    ``USE_AUTH_BACKEND``, off by default -- so without a write-side sweep
+    they outlive every sign-out until the session itself expires."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def test_logout_removes_the_legacy_unscoped_keys(self):
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "logout"})
+        request = self.factory.get("/")
+        request.session = {
+            "oidc_id_token": "legacy.id",
+            "oidc_access_token": "legacy.access",
+            "oidc_refresh_token": "legacy.refresh",
+            "unrelated": "keep",
+        }
+
+        response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 302)
+        for legacy in ("oidc_id_token", "oidc_access_token", "oidc_refresh_token"):
+            self.assertNotIn(legacy, request.session)
+        self.assertEqual(request.session.get("unrelated"), "keep")
+
+    def test_a_legacy_id_token_is_not_replayed_as_a_hint(self):
+        """Removing it must not resurrect it as ``id_token_hint`` -- that
+        would be a fallback *read*, which is exactly what the namespacing
+        refuses."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "logout"})
+        request = self.factory.get("/")
+        request.session = {"oidc_id_token": "legacy.id"}
+
+        response = view(request, auth_server="default")
+
+        self.assertNotIn("id_token_hint", response.url)
+        self.assertNotIn("legacy.id", response.url)
+
+
+@override_settings(
+    OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
+    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+)
+class TestCallbackDoesNotLogCredentials(TestCase):
+    """The id_token must never reach the application log.
+
+    ``callback`` accepts an id_token straight from the POST body on the
+    username-form path (``from_username_form=1``), so a token in the log is
+    not merely sensitive at rest -- anyone who can read logs can replay it
+    and obtain a session as that user, and with the account proxy mixed in,
+    their Keycloak account too.
+    """
+
+    SECRET_TOKEN = "HEADER.SECRET_TOKEN_MATERIAL.SIGNATURE"
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _run(self, claims, data=None):
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+            return_value=claims,
+        ):
+            request = self.factory.post(
+                "/", data={"id_token": self.SECRET_TOKEN, **(data or {})}
+            )
+            request.session = {}
+            with self.assertLogs("oidc.viewsets", level="DEBUG") as captured:
+                # A log line is not guaranteed on every path; emit one so
+                # assertLogs always has something and the test is about
+                # *what* was logged, not whether anything was.
+                logging.getLogger("oidc.viewsets").info("probe")
+                response = view(request, auth_server="default")
+        return response, "\n".join(captured.output)
+
+    def test_the_uniqueness_conflict_path_does_not_log_the_id_token(self):
+        # Username collides, email does not -- an email match would find the
+        # existing user and log straight in, never reaching the conflict.
+        User.objects.create(username="taken", email="incumbent@example.com")
+
+        response, logged = self._run(
+            {
+                "given_name": "Taken",
+                "family_name": "User",
+                "email": "newcomer@example.com",
+                "preferred_username": "taken",
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["error"], "Username field is already in use.")
+        self.assertNotIn(self.SECRET_TOKEN, logged)
+        self.assertNotIn("SECRET_TOKEN_MATERIAL", logged)
+
+    def test_a_field_validation_failure_does_not_forge_log_lines(self):
+        """The rejected value is caller-supplied; interpolated raw, a
+        newline in it would forge an extra log line."""
+        response, logged = self._run(
+            {
+                "given_name": "Bad",
+                "family_name": "User",
+                "email": "bad@example.com",
+                "preferred_username": "ok_username",
+            },
+            data={
+                "username": "x\nINFO:oidc.viewsets:forged line",
+                USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+            },
+        )
+
+        self.assertNotIn(self.SECRET_TOKEN, logged)
+        # The newline must be escaped by %r rather than starting a new line.
+        for line in logged.splitlines():
+            self.assertNotEqual(line.strip(), "forged line")
+
+
+class TestCredentialBearingSessionHardening(TestCase):
+    """Guards on the session that now carries access and refresh tokens.
+
+    Before this feature the session held only an id_token the browser had
+    already seen. Storing a *refresh* token there raises the stakes on two
+    Django-level choices the library was previously indifferent to.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+        SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+    )
+    def test_a_proxy_viewset_refuses_cookie_backed_sessions(self):
+        """Signed-cookie sessions are signed but not encrypted, and survive
+        logout because there is no server-side record to delete."""
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+            KeycloakOpenIDConnectViewset()
+        self.assertIn("signed_cookies", str(ctx.exception))
+        self.assertIn("SESSION_ENGINE", str(ctx.exception))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+        SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+    )
+    def test_a_viewset_that_stashes_nothing_is_unaffected(self):
+        """The base viewset keeps only the id_token, which the browser
+        already holds -- refusing cookie sessions there would be gratuitous.
+        """
+        UserModelOpenIDConnectViewset()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_the_session_key_is_rotated_when_tokens_are_written(self):
+        """Session fixation: the id the request arrived with must not be the
+        one that ends up holding the tokens."""
+        from django.contrib.sessions.backends.db import SessionStore
+
+        session = SessionStore()
+        session.create()
+        original_key = session.session_key
+
+        view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value={
+                    "id_token": "idp-id-token",
+                    "access_token": "idp-access-token",
+                    "refresh_token": "idp-refresh-token",
+                },
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value={
+                    "given_name": "Rot",
+                    "family_name": "User",
+                    "email": "rot@example.com",
+                    "preferred_username": "rotuser",
+                },
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = session
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIsNotNone(session.session_key)
+        self.assertNotEqual(session.session_key, original_key)
+        # Rotation must not lose the tokens it exists to protect.
+        self.assertEqual(
+            session[token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")],
+            "idp-access-token",
+        )
+
+
+class TestOutboundRequestsHaveTimeouts(TestCase):
+    """``requests`` waits forever by default, so an IdP that accepts the
+    connection then stalls pins the worker. Every proxy call and every
+    callback goes through this client."""
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        }
+    )
+    def test_the_account_request_passes_a_timeout(self):
+        client = OpenIDClient("default")
+        upstream = MagicMock(status_code=200, content=b"{}")
+        upstream.json.return_value = {}
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            client.request_keycloak_account("tok", "GET", "/sessions")
+        self.assertIsNotNone(mock_request.call_args.kwargs.get("timeout"))
+
+    @override_settings(OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS)
+    def test_the_token_refresh_passes_a_timeout(self):
+        client = OpenIDClient("default")
+        upstream = MagicMock(status_code=200)
+        upstream.json.return_value = {"access_token": "a"}
+        with patch("oidc.client.requests.post", return_value=upstream) as mock_post:
+            client.refresh_access_token("refresh")
+        self.assertIsNotNone(mock_post.call_args.kwargs.get("timeout"))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "REQUEST_TIMEOUT": (1, 2),
+            },
+        }
+    )
+    def test_the_timeout_is_configurable_per_auth_server(self):
+        self.assertEqual(OpenIDClient("default").request_timeout, (1, 2))
+
+
+class TestSessionBackendDeployCheck(TestCase):
+    """The per-request ``ImproperlyConfigured`` only reaches the first user
+    who tries to sign in. The deploy check catches it at ``manage.py check``
+    instead, which is where a misconfiguration this consequential belongs.
+    """
+
+    @override_settings(
+        SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "oidc.keycloak.KeycloakOpenIDConnectViewset",
+        },
+    )
+    def test_cookie_sessions_plus_a_token_stashing_viewset_is_an_error(self):
+        errors = check_session_backend_can_hold_tokens(None)
+        self.assertEqual([e.id for e in errors], ["oidc.E001"])
+        self.assertIn("signed_cookies", errors[0].msg)
+
+    @override_settings(
+        SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_cookie_sessions_alone_are_fine(self):
+        """The default viewset keeps only the id_token, which the browser
+        already holds -- flagging that would be gratuitous."""
+        self.assertEqual(check_session_backend_can_hold_tokens(None), [])
+
+    @override_settings(
+        SESSION_ENGINE="django.contrib.sessions.backends.cached_db",
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "oidc.keycloak.KeycloakOpenIDConnectViewset",
+        },
+    )
+    def test_a_server_side_backend_is_fine(self):
+        self.assertEqual(check_session_backend_can_hold_tokens(None), [])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "oidc.keycloak.KeycloakOpenIDConnectViewset",
+        },
+    )
+    def test_the_django_default_backend_is_fine(self):
+        """SESSION_ENGINE unset must not be read as the cookie backend."""
+        self.assertEqual(check_session_backend_can_hold_tokens(None), [])
+
+    @override_settings(
+        SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "nonexistent.module.Viewset",
+        },
+    )
+    def test_an_unresolvable_viewset_is_left_to_its_own_error(self):
+        """Not this check's job to report a broken VIEWSET_CLASS, and it
+        must not mask it by raising from here."""
+        self.assertEqual(check_session_backend_can_hold_tokens(None), [])

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -23,6 +23,7 @@ from oidc.checks import (
     check_actions_survive_subclassing,
     check_session_backend_can_hold_tokens,
 )
+from oidc.keycloak import _sid_from_id_token
 from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
 from oidc.keycloak import KeycloakOpenIDConnectViewset
 from oidc.permissions import IsCsrfSafeAccountRequest, get_account_request_header
@@ -107,6 +108,26 @@ OPENID_CONNECT_VIEWSET_CONFIG = {
     "SSO_COOKIE_DOMAIN": ".example.com",
     "SSO_COOKIE_MAX_AGE": 60 * 60 * 24 * 30,
 }
+
+
+# Settings shapes repeated across many test classes. Hoisted so a change to
+# the fixture is made once, and so the assertions aren't buried in setup.
+WITH_DEFAULT_SETTINGS = override_settings(
+    OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
+    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+)
+
+#: ...plus an ACCOUNT_ENDPOINT, which the account-proxy actions require.
+WITH_ACCOUNT_ENDPOINT = override_settings(
+    OPENID_CONNECT_AUTH_SERVERS={
+        **OPENID_CONNECT_AUTH_SERVERS,
+        "default": {
+            **OPENID_CONNECT_AUTH_SERVERS["default"],
+            "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+        },
+    },
+    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+)
 
 
 class TestUserModelOpenIDConnectViewset(TestCase):
@@ -973,10 +994,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertIn("login_hint=alice%40example.com", response.url)
         self.assertNotIn("evil_param", response.url)
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_DEFAULT_SETTINGS
     def test_login_default_allowlist_drops_all_query_params(self):
         view = BaseOpenIDConnectViewset.as_view({"get": "login"})
 
@@ -1009,10 +1027,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertIn("kc_idp_hint=onadata", response.url)
         self.assertNotIn("next=", response.url)
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_DEFAULT_SETTINGS
     def test_logout_forwards_id_token_hint_from_session(self):
         """The id_token stashed by the callback is threaded as
         ``id_token_hint`` on the end-session URL and popped from
@@ -1095,10 +1110,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertIn("id_token_hint=ey.legit.jwt", response.url)
         self.assertNotIn("ey.attacker.jwt", response.url)
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_DEFAULT_SETTINGS
     def test_logout_default_allowlist_drops_all_query_params(self):
         """No ``LOGOUT_QUERY_PARAM_ALLOWLIST`` configured → empty set →
         all query params dropped. Mirrors the login default."""
@@ -1112,16 +1124,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         # End-session URL untouched — bare endpoint, no stray `?`/`&`.
         self.assertEqual(response.url, "http://localhost:3000")
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_account_proxy_no_session_token_returns_401(self):
         """No stashed access_token → 401, never reach Keycloak."""
         view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
@@ -1135,16 +1138,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         # Critical: we never reached out to Keycloak.
         mock_request.assert_not_called()
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_account_proxy_refresh_rejected_by_idp_returns_401(self):
         """The IdP answered and refused the refresh token: the session really
         is dead, so signing in again is the right instruction."""
@@ -1168,16 +1162,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
 
         self.assertEqual(response.status_code, 401)
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_account_proxy_refresh_transport_failure_returns_502(self):
         """Pin: an unreachable IdP must not be reported as an expired session.
         Doing so sends the user through a re-login that cannot fix a server
@@ -1203,16 +1188,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
 
         self.assertEqual(response.status_code, 502)
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_proxy_does_not_disguise_our_own_bugs_as_upstream_failures(self):
         """Pin: only transport/config errors become 502. A defect in our own
         response handling must surface as a 500 with a traceback, not as
@@ -1229,16 +1205,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             with self.assertRaises(KeyError):
                 view(request, auth_server="default")
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_account_proxy_refreshes_on_401_and_retries(self):
         """Keycloak 401 → refresh access_token via refresh_token → retry.
         Session writeback so the next request uses the fresh token."""
@@ -1288,10 +1255,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             request.session["oidc_refresh_token:default"], "fresh.refresh.token"
         )
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_DEFAULT_SETTINGS
     def test_account_proxy_returns_503_when_endpoint_not_configured(self):
         """Deployments that haven't wired ``ACCOUNT_ENDPOINT`` get a
         clear 503 — never reach Keycloak with a half-baked URL."""
@@ -1306,16 +1270,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(response.status_code, 503)
         mock_post.assert_not_called()
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_keycloak_account_request_get_passes_through_status_and_body(self):
         """Shared helper round-trips method/path/body and surfaces upstream
         (status, body). Refresh + retry exists already; this locks the
@@ -1345,16 +1300,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             kwargs["headers"]["Authorization"], "Bearer stashed.access.token"
         )
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_sessions_list_flattens_devices_into_rows(self):
         """Keycloak returns DeviceRepresentation[] with nested sessions[].
         Proxy flattens to a per-session list so the SPA renders rows,
@@ -1414,16 +1360,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(rows[1]["os"], "Windows")
         self.assertFalse(rows[1]["current"])
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_sessions_list_marks_only_sid_match_current_when_grouped(self):
         """Two browsers on one machine (e.g. normal + incognito on
         localhost) collapse into a single device that Keycloak flags
@@ -1461,16 +1398,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertFalse(by_id["sess-old"]["current"])
         self.assertTrue(by_id["sess-current"]["current"])
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_sessions_revoke_one_forwards_id(self):
         view = KeycloakOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
         request = self.factory.delete("/")
@@ -1492,16 +1420,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(args[0], "DELETE")
         self.assertTrue(args[1].endswith("/sessions/other-sid"))
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_sessions_revoke_one_rejects_current_session(self):
         view = KeycloakOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
         request = self.factory.delete("/")
@@ -1519,16 +1438,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         # Crucial: we never reach Keycloak.
         mock_request.assert_not_called()
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_sessions_revoke_others_passes_current_false(self):
         """DELETE /sessions revokes every session EXCEPT the current one."""
         view = KeycloakOpenIDConnectViewset.as_view(
@@ -1550,16 +1460,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(args[0], "DELETE")
         self.assertIn("/sessions?current=false", args[1])
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_linked_list_forwards_keycloak_body_verbatim(self):
         view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
         request = self.factory.get("/")
@@ -1584,16 +1485,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, keycloak_body)
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_linked_unlink_forwards_provider_alias(self):
         view = KeycloakOpenIDConnectViewset.as_view({"delete": "linked_unlink"})
         request = self.factory.delete("/")
@@ -1607,16 +1499,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         args, _ = mock_request.call_args
         self.assertTrue(args[1].endswith("/linked-accounts/google"))
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_linked_unlink_rejects_invalid_provider_alias(self):
         view = KeycloakOpenIDConnectViewset.as_view({"delete": "linked_unlink"})
         request = self.factory.delete("/")
@@ -1626,16 +1509,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(response.status_code, 400)
         mock_request.assert_not_called()
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_linked_link_url_forwards_body(self):
         """The link-url action forwards Keycloak's linked-account
         representation verbatim — the SPA extracts ``accountLinkUri``
@@ -1667,16 +1541,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             },
         )
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_credentials_list_forwards_body(self):
         """The credentials action forwards Keycloak's nested
         credential-metadata wire shape verbatim — reshaping for
@@ -2555,10 +2420,7 @@ class TestLoginNextValidation(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_DEFAULT_SETTINGS
     @patch("oidc.client.cache.set")
     def test_safe_relative_next_is_cached(self, mock_cache_set):
         view = BaseOpenIDConnectViewset.as_view({"get": "login"})
@@ -3063,16 +2925,7 @@ class AccountProxyCsrfTests(TestCase):
         )
         self.assertTrue(self.perm.has_permission(request, self.view))
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_permitted_request_reaches_the_action(self):
         """Header + no cross-origin Origin: the permission passes and the
         action runs through to a concrete success."""
@@ -3239,16 +3092,7 @@ class TestSessionIdPathTraversal(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_dot_segment_session_id_is_rejected_before_any_upstream_call(self):
         view = KeycloakOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
         for session_id in ("..", ".", "..%2f.."):
@@ -3263,16 +3107,7 @@ class TestSessionIdPathTraversal(TestCase):
                 # The point of the guard: Keycloak is never contacted.
                 mock_request.assert_not_called()
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_a_real_session_id_still_reaches_the_expected_url(self):
         """The guard must not narrow the endpoint to uselessness."""
         view = KeycloakOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
@@ -3340,16 +3175,7 @@ class TestMisconfigurationIsNotAnOutage(TestCase):
         # handed to requests and no call leaves the process.
         mock_post.assert_not_called()
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_a_non_json_token_response_is_502_not_503(self):
         """``requests`` raises ``JSONDecodeError`` for a non-JSON body, and it
         subclasses both ``ValueError`` and ``RequestException``. Catching bare
@@ -3396,16 +3222,7 @@ class TestProxyErrorsAreAlwaysJson(TestCase):
     degrades to a bare status code on the client, so every failure mode has
     to stay JSON."""
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_unknown_auth_server_answers_json(self):
         response = self.client.get("/oidc/nosuchserver/sessions")
         self.assertEqual(response.status_code, 400)
@@ -3663,16 +3480,7 @@ class TestLogoutClearsStashedTokens(TestCase):
         mock_request.assert_not_called()
 
 
-@override_settings(
-    OPENID_CONNECT_AUTH_SERVERS={
-        **OPENID_CONNECT_AUTH_SERVERS,
-        "default": {
-            **OPENID_CONNECT_AUTH_SERVERS["default"],
-            "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-        },
-    },
-    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-)
+@WITH_ACCOUNT_ENDPOINT
 class TestProviderAliasCharset(TestCase):
     """Keycloak accepts dots and mixed case in an identity-provider alias.
 
@@ -4013,16 +3821,7 @@ class TestReadsAreOriginGated(TestCase):
         request = self.factory.post("/", HTTP_ORIGIN="http://testserver")
         self.assertFalse(self.perm.has_permission(request, self.view))
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-            },
-        },
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_ACCOUNT_ENDPOINT
     def test_a_cross_origin_read_never_reaches_keycloak(self):
         """End to end: even with hostile CORS reflecting the attacker's
         origin, the listing is never fetched, so there is nothing for the
@@ -4050,16 +3849,7 @@ class TestReadsAreOriginGated(TestCase):
         mock_request.assert_not_called()
 
 
-@override_settings(
-    OPENID_CONNECT_AUTH_SERVERS={
-        **OPENID_CONNECT_AUTH_SERVERS,
-        "default": {
-            **OPENID_CONNECT_AUTH_SERVERS["default"],
-            "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-        },
-    },
-    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-)
+@WITH_ACCOUNT_ENDPOINT
 class TestPendingTokensBelongToOneFlow(TestCase):
     """Pending slots are per-provider, but a session can run two logins.
 
@@ -4336,10 +4126,7 @@ class TestProviderAliasAnchoring(TestCase):
                 self.assertFalse(_is_valid_provider_alias(alias))
 
 
-@override_settings(
-    OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
-    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-)
+@WITH_DEFAULT_SETTINGS
 class TestLogoutClearsPreNamespacingTokens(TestCase):
     """A session established before the per-provider rename holds bare
     ``oidc_id_token`` etc. Nothing reads those any more, but only
@@ -4381,10 +4168,7 @@ class TestLogoutClearsPreNamespacingTokens(TestCase):
         self.assertNotIn("legacy.id", response.url)
 
 
-@override_settings(
-    OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
-    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-)
+@WITH_DEFAULT_SETTINGS
 class TestCallbackDoesNotLogCredentials(TestCase):
     """The id_token must never reach the application log.
 
@@ -4416,14 +4200,14 @@ class TestCallbackDoesNotLogCredentials(TestCase):
                 # *what* was logged, not whether anything was.
                 logging.getLogger("oidc.viewsets").info("probe")
                 response = view(request, auth_server="default")
-        return response, "\n".join(captured.output)
+        return response, "\n".join(captured.output), captured
 
     def test_the_uniqueness_conflict_path_does_not_log_the_id_token(self):
         # Username collides, email does not -- an email match would find the
         # existing user and log straight in, never reaching the conflict.
         User.objects.create(username="alice", email="alice@example.com")
 
-        response, logged = self._run(
+        response, logged, captured = self._run(
             {
                 "given_name": "Alice",
                 "family_name": "User",
@@ -4437,26 +4221,29 @@ class TestCallbackDoesNotLogCredentials(TestCase):
         self.assertNotIn(self.SECRET_TOKEN, logged)
         self.assertNotIn("SECRET_TOKEN_MATERIAL", logged)
 
-    def test_a_field_validation_failure_does_not_forge_log_lines(self):
-        """The rejected value is caller-supplied; interpolated raw, a
-        newline in it would forge an extra log line."""
-        response, logged = self._run(
-            {
-                "given_name": "Bob",
-                "family_name": "User",
-                "email": "bob@example.com",
-                "preferred_username": "bob_username",
-            },
-            data={
-                "username": "x\nINFO:oidc.viewsets:forged line",
-                USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
-            },
-        )
+    def test_a_rejected_field_value_cannot_forge_a_log_line(self):
+        """``validate_fields`` echoes the rejected value. Interpolated with
+        an f-string a newline in it would start a second log line that reads
+        as its own entry; %r escapes it.
 
-        self.assertNotIn(self.SECRET_TOKEN, logged)
-        # The newline must be escaped by %r rather than starting a new line.
-        for line in logged.splitlines():
-            self.assertNotEqual(line.strip(), "forged line")
+        Driven straight at the method: routed through ``callback`` the
+        payload never arrives, because ``USE_EMAIL_USERNAME`` rewrites an
+        invalid username from the email before validation sees it.
+        """
+        viewset = UserModelOpenIDConnectViewset()
+        forged = "x\nINFO:oidc.viewsets:forged line"
+
+        with self.assertLogs("oidc.viewsets", level="INFO") as captured:
+            with self.assertRaises(ValueError):
+                viewset.validate_fields({"username": forged})
+
+        echoed = [r for r in captured.records if r.getMessage().startswith("Invalid")]
+        self.assertEqual(len(echoed), 1, "the rejected value was never logged")
+        self.assertNotIn(
+            chr(10),
+            echoed[0].getMessage(),
+            "a caller-supplied newline reached the log verbatim",
+        )
 
 
 class TestCredentialBearingSessionHardening(TestCase):
@@ -4494,10 +4281,7 @@ class TestCredentialBearingSessionHardening(TestCase):
         """
         UserModelOpenIDConnectViewset()
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
-        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-    )
+    @WITH_DEFAULT_SETTINGS
     def test_the_session_key_is_rotated_when_tokens_are_written(self):
         """Session fixation: the id the request arrived with must not be the
         one that ends up holding the tokens."""
@@ -4828,16 +4612,7 @@ class TestOverriddenActionDeployCheck(TestCase):
         self.assertIn("callback", routed)
 
 
-@override_settings(
-    OPENID_CONNECT_AUTH_SERVERS={
-        **OPENID_CONNECT_AUTH_SERVERS,
-        "default": {
-            **OPENID_CONNECT_AUTH_SERVERS["default"],
-            "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
-        },
-    },
-    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
-)
+@WITH_ACCOUNT_ENDPOINT
 class TestSubclassRefusalLeavesNoTokens(TestCase):
     """A subclass can refuse a login the library itself would have accepted
     -- overriding ``generate_successful_response`` is the documented way,
@@ -4901,3 +4676,210 @@ class TestSubclassRefusalLeavesNoTokens(TestCase):
 
         self.assertEqual(response.status_code, 401)
         mock_request.assert_not_called()
+
+
+class TestSidFromIdToken(TestCase):
+    """``_sid_from_id_token`` is patched in every test that depends on it, so
+    the real contract was pinned nowhere. It drives two user-visible things:
+    the 409 that stops you revoking the session you are using, and the
+    ``current`` flag in the sessions list. Reading the wrong claim, or
+    demanding a signature the caller cannot supply, turns both off silently
+    -- and the ``current`` fallback is the two-browsers-look-identical bug
+    the flattening exists to fix.
+    """
+
+    def _token(self, claims):
+        return jwt.encode(claims, "irrelevant-secret", algorithm="HS256")
+
+    def test_reads_the_sid_claim(self):
+        self.assertEqual(
+            _sid_from_id_token(self._token({"sid": "abc-123", "sub": "u1"})),
+            "abc-123",
+        )
+
+    def test_does_not_read_session_state_instead(self):
+        """Keycloak emits both; ``session_state`` is the older, different
+        value, so picking it up would be a silent behaviour swap."""
+        token = self._token({"session_state": "wrong-one", "sub": "u1"})
+        self.assertIsNone(_sid_from_id_token(token))
+
+    def test_decodes_without_verifying_the_signature(self):
+        """The token was verified at callback time; here we only need a
+        claim, and the signing key is not available on this path."""
+        token = jwt.encode({"sid": "abc-123"}, "some-other-key", algorithm="HS256")
+        self.assertEqual(_sid_from_id_token(token), "abc-123")
+
+    def test_a_malformed_token_yields_none_rather_than_raising(self):
+        for token in ("not-a-jwt", "", "a.b.c"):
+            with self.subTest(token=token):
+                self.assertIsNone(_sid_from_id_token(token))
+
+    def test_a_token_without_the_claim_yields_none(self):
+        self.assertIsNone(_sid_from_id_token(self._token({"sub": "u1"})))
+
+
+class TestDeployChecksAreRegistered(TestCase):
+    """Both checks exist to fail ``manage.py check`` rather than the first
+    user to sign in. Calling the functions directly proves their logic but
+    not that they ever run, which is the property that matters."""
+
+    def test_both_checks_run_through_djangos_registry(self):
+        from django.core.checks import registry
+
+        registered = {c.__name__ for c in registry.registry.get_checks()}
+        self.assertIn("check_session_backend_can_hold_tokens", registered)
+        self.assertIn("check_actions_survive_subclassing", registered)
+
+    @override_settings(
+        SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "oidc.keycloak.KeycloakOpenIDConnectViewset",
+        },
+    )
+    def test_a_misconfigured_deployment_fails_run_checks(self):
+        """End to end through the registry, the way a deploy would hit it."""
+        from django.core.checks import run_checks
+
+        self.assertIn("oidc.E001", {e.id for e in run_checks()})
+
+
+@WITH_ACCOUNT_ENDPOINT
+class TestAccountCallFailureModes(TestCase):
+    """Everything downstream of the first Keycloak response. The 502 mapping
+    was only ever driven through the *refresh* call, so the account call's
+    own transport and parsing paths were unexercised."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _get(self, **patch_kwargs):
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"): "t"}
+        with patch("oidc.client.requests.request", **patch_kwargs):
+            return view(request, auth_server="default")
+
+    def test_an_unreachable_idp_is_a_502_not_an_empty_success(self):
+        response = self._get(side_effect=requests.ConnectionError("unreachable"))
+        self.assertEqual(response.status_code, 502)
+        self.assertIn("error", response.data)
+
+    def test_a_timeout_is_also_a_502(self):
+        """``Timeout`` is a RequestException subclass -- pinned because the
+        timeouts this branch added make it newly reachable."""
+        response = self._get(side_effect=requests.Timeout("slow"))
+        self.assertEqual(response.status_code, 502)
+
+    def test_a_non_json_body_does_not_raise(self):
+        """A fronting proxy answering with HTML must not 500 us."""
+        upstream = MagicMock(status_code=200, content=b"<html>oops</html>")
+        upstream.json.side_effect = ValueError("no json")
+        response = self._get(return_value=upstream)
+        self.assertEqual(response.status_code, 200)
+
+    def test_an_upstream_error_is_wrapped_in_the_envelope_the_spa_reads(self):
+        upstream = MagicMock(status_code=403, content=b'{"error":"forbidden"}')
+        upstream.json.return_value = {"error": "forbidden"}
+        response = self._get(return_value=upstream)
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("error", response.data)
+        self.assertEqual(response.data["upstream"], {"error": "forbidden"})
+
+    def test_a_401_with_no_stashed_refresh_token_stays_401(self):
+        upstream = MagicMock(status_code=401, content=b"{}")
+        upstream.json.return_value = {"error": "invalid_token"}
+        response = self._get(return_value=upstream)
+        self.assertEqual(response.status_code, 401)
+
+    def test_a_refresh_that_returns_no_access_token_is_a_401(self):
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {
+            token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"): "expired",
+            token_session_key(REFRESH_TOKEN_SESSION_KEY, "default"): "r",
+        }
+        rejected = MagicMock(status_code=401, content=b"{}")
+        rejected.json.return_value = {}
+        refreshed = MagicMock(status_code=200)
+        refreshed.json.return_value = {"token_type": "Bearer"}  # no access_token
+        with (
+            patch("oidc.client.requests.request", return_value=rejected),
+            patch("oidc.client.requests.post", return_value=refreshed),
+        ):
+            response = view(request, auth_server="default")
+        self.assertEqual(response.status_code, 401)
+
+
+@WITH_DEFAULT_SETTINGS
+class TestRemainingTokenLifecycleGuards(TestCase):
+    """Guards whose removal previously left the suite green."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def test_logout_clears_the_pending_slots(self):
+        """A login abandoned at the username form parks a refresh token.
+        Logout is the only thing that removes it -- the session is not
+        flushed unless USE_AUTH_BACKEND is on."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "logout"})
+        request = self.factory.get("/")
+        request.session = {
+            pending_token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"): "a",
+            pending_token_session_key(REFRESH_TOKEN_SESSION_KEY, "default"): "r",
+            pending_token_session_key(ID_TOKEN_SESSION_KEY, "default"): "i",
+        }
+
+        view(request, auth_server="default")
+
+        self.assertEqual(
+            [v for v in request.session.values() if v in {"a", "r", "i"}],
+            [],
+            f"pending credentials survived logout: {request.session}",
+        )
+
+    def test_a_viewset_that_does_not_stash_parks_nothing(self):
+        """``stash_oidc_tokens`` must gate the *park*, not just the active
+        write -- otherwise every non-proxy deployment starts storing refresh
+        tokens at the username form."""
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value={
+                    "id_token": "i",
+                    "access_token": "secret-access",
+                    "refresh_token": "secret-refresh",
+                },
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                # Email present (so no userinfo round-trip) but its local
+                # part is too short to derive a valid username from -- the
+                # entry form, which is the only path that parks anything.
+                return_value={
+                    "given_name": "Bob",
+                    "family_name": "User",
+                    "email": "c@example.com",
+                },
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = {}
+            view(request, auth_server="default")
+
+        self.assertEqual(
+            [v for v in request.session.values() if str(v).startswith("secret-")],
+            [],
+            f"a non-proxy viewset parked a token pair: {request.session}",
+        )
+
+    def test_the_jwks_fetch_passes_a_timeout(self):
+        """On the hot path of every login -- a stalled IdP here pins the
+        worker, which is what the timeout exists to prevent."""
+        client = OpenIDClient("default")
+        upstream = MagicMock(status_code=200)
+        upstream.json.return_value = {"keys": []}
+        with patch("oidc.client.requests.get", return_value=upstream) as mock_get:
+            client._retrieve_jwks_related_to_kid("some-kid")
+        self.assertIsNotNone(mock_get.call_args.kwargs.get("timeout"))

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -5091,6 +5091,69 @@ class TestDeployCheckComparesRoutesNotNames(TestCase):
     @override_settings(
         OPENID_CONNECT_VIEWSET_CONFIG={
             **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.MovedRouteViewset",
+        }
+    )
+    def test_a_changed_url_path_is_reported(self):
+        errors = check_actions_survive_subclassing(None)
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.DetailRedeclareViewset",
+        }
+    )
+    def test_a_flipped_detail_flag_is_reported(self):
+        """detail=True inserts a pk segment, so the SPA's URL 404s and
+        reverse() without a pk raises NoReverseMatch."""
+        errors = check_actions_survive_subclassing(None)
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.UnguardedRedeclareViewset",
+        }
+    )
+    def test_dropping_the_view_kwargs_is_reported(self):
+        """The route matches by path, name and verb, but permission_classes
+        falls back to AllowAny -- the account proxy's only cross-origin
+        defence, gone with nothing to show for it. E002's own hint used to
+        describe exactly this override."""
+        errors = check_actions_survive_subclassing(None)
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.TightenedRedeclareViewset",
+        }
+    )
+    def test_adding_a_permission_class_is_not_reported(self):
+        """Only widening matters. Demanding equality would hard-fail a
+        deployment for tightening its own account routes."""
+        self.assertEqual(check_actions_survive_subclassing(None), [])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.RenamedCompanionViewset",
+        }
+    )
+    def test_renaming_a_companion_handler_is_not_reported(self):
+        """``mapping`` holds handler names, so comparing it pairwise hard-
+        fails a subclass that kept both verbs and merely renamed a method --
+        and E002 is an Error, so that stops manage.py check outright."""
+        from tests.project_viewsets import RenamedCompanionViewset
+
+        self.assertEqual(check_actions_survive_subclassing(None), [])
+        routed = {a.__name__: a for a in RenamedCompanionViewset.get_extra_actions()}
+        self.assertEqual(sorted(routed["sessions_list"].mapping), ["delete", "get"])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
             "VIEWSET_CLASS": "tests.project_viewsets.RedeclaredOverrideViewset",
         }
     )

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -19,7 +19,10 @@ import requests
 from mock import MagicMock, patch
 from rest_framework.test import APIRequestFactory
 
-from oidc.checks import check_session_backend_can_hold_tokens
+from oidc.checks import (
+    check_actions_survive_subclassing,
+    check_session_backend_can_hold_tokens,
+)
 from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
 from oidc.keycloak import KeycloakOpenIDConnectViewset
 from oidc.permissions import IsCsrfSafeAccountRequest, get_account_request_header
@@ -4770,3 +4773,56 @@ class TestTokensSurviveDjangoLogin(TestCase):
             session.get(token_session_key(ID_TOKEN_SESSION_KEY, "default")),
             "idp-id-token",
         )
+
+
+class TestOverriddenActionDeployCheck(TestCase):
+    """A subclass that overrides an ``@action`` without re-declaring it
+    silently loses the route: DRF's router reads the metadata off the
+    function, and a plain override replaces the function. The endpoint then
+    404s with nothing in either repo pointing at the cause, which is why it
+    is caught at ``manage.py check`` rather than left to a user."""
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.PlainOverrideViewset",
+        }
+    )
+    def test_a_plain_override_is_reported(self):
+        errors = check_actions_survive_subclassing(None)
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+        self.assertIn("login", errors[0].msg)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.RedeclaredOverrideViewset",
+        }
+    )
+    def test_re_declaring_the_action_clears_it(self):
+        """The documented fix must actually satisfy the check."""
+        self.assertEqual(check_actions_survive_subclassing(None), [])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "oidc.keycloak.KeycloakOpenIDConnectViewset",
+        }
+    )
+    def test_the_shipped_viewsets_are_clean(self):
+        self.assertEqual(check_actions_survive_subclassing(None), [])
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.PlainOverrideViewset",
+        }
+    )
+    def test_the_route_really_is_missing(self):
+        """Pins that the check describes a real consequence, not a style
+        rule -- the action is genuinely absent from the router's view."""
+        from tests.project_viewsets import PlainOverrideViewset
+
+        routed = {a.__name__ for a in PlainOverrideViewset.get_extra_actions()}
+        self.assertNotIn("login", routed)
+        self.assertIn("callback", routed)

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -7,6 +7,7 @@ import logging
 from types import SimpleNamespace
 
 from django.contrib.auth import get_user_model
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
@@ -5132,12 +5133,92 @@ class TestMixinOrderIsEnforced(TestCase):
         self.assertNotIn("Put the mixin first", message)
 
 
+class TestParkedPairSurvivesTheLoginFlush(TestCase):
+    """Under USE_AUTH_BACKEND, ``generate_successful_response`` runs Django's
+    ``login()``, which flushes the session when a different user was
+    authenticated in it. A pair the code exchange returned is in locals and
+    survives; the form path's pair is in the session and does not, so the
+    user ends up signed in with an id_token and no tokens -- a proxy that
+    401s for the whole session with nothing to indicate why."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _with_session(self, data):
+        request = self.factory.post("/", data=data)
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        return request
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "USE_AUTH_BACKEND": True,
+            "AUTH_BACKEND": "django.contrib.auth.backends.ModelBackend",
+        },
+    )
+    def test_a_form_login_as_a_different_user_keeps_its_pair(self):
+        claims = {"given_name": "Alice", "family_name": "User", "email": "a@x.io"}
+        view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+        incumbent = User.objects.create_user("someone_else", "other@x.io", "pw")
+
+        first = self._with_session({"code": "auth-code"})
+        first.session["_auth_user_id"] = str(incumbent.pk)
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value={
+                    "id_token": "id-alice",
+                    "access_token": "at-alice",
+                    "refresh_token": "rt-alice",
+                },
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value=claims,
+            ),
+        ):
+            view(first, auth_server="default")
+        self.assertTrue([k for k in first.session.keys() if k.endswith(":pending")])
+
+        resubmit = self._with_session(
+            {
+                "id_token": "id-alice",
+                "username": "alice_chosen",
+                USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+            }
+        )
+        for key, value in first.session.items():
+            resubmit.session[key] = value
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+            return_value=claims,
+        ):
+            response = view(resubmit, auth_server="default")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            resubmit.session.get(
+                token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")
+            ),
+            "at-alice",
+            "login()'s flush took the parked pair with it",
+        )
+
+
 @WITH_ACCOUNT_ENDPOINT
 class TestRefusalDrainsParkedTokens(TestCase):
     """A login refused *at the username form* parks a pair on the way in.
-    ``_persist_oidc_tokens`` is the only thing that drains the pending
-    slots, and the success guard skips it on refusal -- so the pair stays.
-    A refused caller never reaches logout, so nothing else clears it."""
+    Storing the tokens is what drains the pending slots, and the success
+    guard skips it on refusal -- so the pair stays. A refused caller never
+    reaches logout, so nothing else clears it."""
 
     TOKENS = {
         "id_token": "idp-id-token",

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -4940,6 +4940,21 @@ class TestMixinOrderIsEnforced(TestCase):
     def test_the_shipped_composition_still_builds(self):
         self.assertTrue(KeycloakOpenIDConnectViewset.stash_oidc_tokens)
 
+    def test_an_explicit_opt_out_is_not_told_to_reorder(self):
+        """Refusing is right -- proxy routes that always 401 are worse --
+        but the mixin is already first here, so "put the mixin first" would
+        send the reader chasing a problem they do not have."""
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+
+            class OptOut(  # noqa: F841
+                KeycloakAccountMixin, UserModelOpenIDConnectViewset
+            ):
+                stash_oidc_tokens = False
+
+        message = str(ctx.exception)
+        self.assertIn("stash_oidc_tokens = False", message)
+        self.assertNotIn("Put the mixin first", message)
+
 
 @WITH_ACCOUNT_ENDPOINT
 class TestRefusalDrainsParkedTokens(TestCase):

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -4912,3 +4912,30 @@ class TestRouteTrailingSlashSymmetry(TestCase):
         ):
             with self.subTest(path=path):
                 resolve(path)
+
+
+class TestMixinOrderIsEnforced(TestCase):
+    """Listing the mixin after the base viewset resolves
+    ``stash_oidc_tokens`` to False. Every route is still generated and login
+    still succeeds, so the only symptom is that the proxy 401s forever --
+    which is why it has to fail at class definition instead."""
+
+    def test_the_wrong_order_is_refused_at_class_definition(self):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+
+            class WrongOrder(  # noqa: F841
+                UserModelOpenIDConnectViewset, KeycloakAccountMixin
+            ):
+                pass
+
+        self.assertIn("KeycloakAccountMixin", str(ctx.exception))
+        self.assertIn("stash_oidc_tokens", str(ctx.exception))
+
+    def test_the_right_order_is_accepted(self):
+        class RightOrder(KeycloakAccountMixin, UserModelOpenIDConnectViewset):
+            pass
+
+        self.assertTrue(RightOrder.stash_oidc_tokens)
+
+    def test_the_shipped_composition_still_builds(self):
+        self.assertTrue(KeycloakOpenIDConnectViewset.stash_oidc_tokens)

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -34,7 +34,7 @@ from oidc.utils import (
     pending_token_session_key,
     token_session_key,
 )
-from tests.project_viewsets import InjectedViewset
+from tests.project_viewsets import InjectedViewset, RefusingViewset
 from oidc.viewsets import (
     DEFAULT_USERNAME_HELP_TEXT,
     DEFAULT_USERNAME_PATTERN,
@@ -4826,3 +4826,78 @@ class TestOverriddenActionDeployCheck(TestCase):
         routed = {a.__name__ for a in PlainOverrideViewset.get_extra_actions()}
         self.assertNotIn("login", routed)
         self.assertIn("callback", routed)
+
+
+@override_settings(
+    OPENID_CONNECT_AUTH_SERVERS={
+        **OPENID_CONNECT_AUTH_SERVERS,
+        "default": {
+            **OPENID_CONNECT_AUTH_SERVERS["default"],
+            "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+        },
+    },
+    OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+)
+class TestSubclassRefusalLeavesNoTokens(TestCase):
+    """A subclass can refuse a login the library itself would have accepted
+    -- overriding ``generate_successful_response`` is the documented way,
+    and the real consumer uses it to reject organization accounts. That
+    refusal must be as final as the library's own: tokens are what the
+    account proxy treats as proof of a session."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _callback(self):
+        view = RefusingViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value={
+                    "id_token": "idp-id-token",
+                    "access_token": "idp-access-token",
+                    "refresh_token": "idp-refresh-token",
+                },
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value={
+                    "given_name": "Alice",
+                    "family_name": "User",
+                    "email": "alice@example.com",
+                    "preferred_username": "alice",
+                },
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = {}
+            response = view(request, auth_server="default")
+        return response, request.session
+
+    def test_a_refused_subclass_login_stores_no_tokens(self):
+        response, session = self._callback()
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            [v for v in session.values() if str(v).startswith("idp-")],
+            [],
+            f"refused login left credentials in the session: {session}",
+        )
+
+    def test_the_proxy_refuses_that_session(self):
+        """The consequence: without this the refused caller can list and
+        revoke their Keycloak sessions through the proxy."""
+        _, session = self._callback()
+
+        proxy = RefusingViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = session
+        unreached = MagicMock(status_code=200, content=b"[]")
+        unreached.json.return_value = []
+        with patch(
+            "oidc.client.requests.request", return_value=unreached
+        ) as mock_request:
+            response = proxy(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 401)
+        mock_request.assert_not_called()

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -3460,10 +3460,10 @@ class TestTokensAreScopedToAuthServer(TestCase):
                 "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
                 return_value={
                     "name": "Scoped User",
-                    "preferred_username": "scoped@example.com",
-                    "given_name": "Scoped",
+                    "preferred_username": "alice@example.com",
+                    "given_name": "Alice",
                     "family_name": "User",
-                    "email": "scoped@example.com",
+                    "email": "alice@example.com",
                 },
             ),
         ):
@@ -3786,10 +3786,10 @@ class TestTokensAreNotStashedOnRefusedLogin(TestCase):
     }
 
     FULL_CLAIMS = {
-        "given_name": "Refused",
+        "given_name": "Bob",
         "family_name": "User",
-        "email": "refused@example.com",
-        "preferred_username": "refused",
+        "email": "bob@example.com",
+        "preferred_username": "bob",
     }
 
     def setUp(self):
@@ -3814,12 +3814,12 @@ class TestTokensAreNotStashedOnRefusedLogin(TestCase):
         return response, request.session
 
     def _assert_no_tokens(self, session):
-        for base_key in (
-            ACCESS_TOKEN_SESSION_KEY,
-            REFRESH_TOKEN_SESSION_KEY,
-            ID_TOKEN_SESSION_KEY,
-        ):
-            self.assertNotIn(token_session_key(base_key, "default"), session)
+        """No token value anywhere in the session -- active or pending. A
+        refused caller never logs out, so nothing would clear a leftover."""
+        for value in self.TOKENS.values():
+            self.assertNotIn(
+                value, session.values(), f"token left at rest in {session}"
+            )
 
     @override_settings(
         OPENID_CONNECT_VIEWSET_CONFIG={
@@ -3841,7 +3841,7 @@ class TestTokensAreNotStashedOnRefusedLogin(TestCase):
         ``_clean_user_data`` backfills it from last_name and username from
         email, but there is no last_name here -- so this is the hard 400
         exit, not the username form."""
-        response, session = self._run_callback({"email": "refused@example.com"})
+        response, session = self._run_callback({"email": "bob@example.com"})
 
         self.assertEqual(response.status_code, 400)
         self._assert_no_tokens(session)
@@ -3909,9 +3909,9 @@ class TestTokensAreNotStashedOnRefusedLogin(TestCase):
         # (the tests/settings.py default) that leaves exactly {username}
         # missing, which is the 200 username-form path.
         claims = {
-            "given_name": "Pend",
+            "given_name": "Dave",
             "family_name": "User",
-            "email": "pend@example.com",
+            "email": "dave@example.com",
         }
         with patch(
             "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
@@ -3938,7 +3938,7 @@ class TestTokensAreNotStashedOnRefusedLogin(TestCase):
                 "/?code=stale-code&state=stale-state",
                 data={
                     "id_token": "idp-id-token",
-                    "username": "pend_chosen",
+                    "username": "dave_chosen",
                     USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
                 },
             )
@@ -4111,60 +4111,60 @@ class TestPendingTokensBelongToOneFlow(TestCase):
         Only the form exit parks a pair, so an interleaving where the second
         tab takes a hard refusal parks nothing and there is no mismatched
         pair to reject — such a test passes with the owner check deleted.
-        Here tab B parks over tab A's slots, so A's resubmit is handed a
-        pair belonging to B and must refuse it.
+        Here tab bob parks over tab alice's slots, so alice's resubmit is handed a
+        pair belonging to bob and must refuse it.
         """
         session = {}
-        x_claims = {
-            "given_name": "Ex",
+        alice_claims = {
+            "given_name": "Alice",
             "family_name": "User",
-            "email": "x@example.com",
+            "email": "a@example.com",
         }
-        y_claims = {
-            "given_name": "Why",
+        bob_claims = {
+            "given_name": "Bob",
             "family_name": "User",
-            "email": "y@example.com",
+            "email": "b@example.com",
         }
 
-        # Tab A: identity X. Derived username "x" is under 3 chars -> form.
+        # Tab alice: identity alice. Derived username "x" is under 3 chars -> form.
         first = self._callback(
             session,
-            x_claims,
+            alice_claims,
             {
-                "id_token": "id-token-X",
-                "access_token": "access-X",
-                "refresh_token": "refresh-X",
+                "id_token": "id-token-alice",
+                "access_token": "access-alice",
+                "refresh_token": "refresh-alice",
             },
         )
         self.assertEqual(first.status_code, 200)
 
-        # Tab B: identity Y, same session, also lands on the form and parks
-        # over A's slots.
+        # Tab bob: identity bob, same session, also lands on the form and parks
+        # over alice's slots.
         second = self._callback(
             session,
-            y_claims,
+            bob_claims,
             {
-                "id_token": "id-token-Y",
-                "access_token": "access-Y",
-                "refresh_token": "refresh-Y",
+                "id_token": "id-token-bob",
+                "access_token": "access-bob",
+                "refresh_token": "refresh-bob",
             },
         )
         self.assertEqual(second.status_code, 200)
         self.assertEqual(
             session.get(pending_token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")),
-            "access-Y",
-            "tab B should have parked over tab A -- otherwise this test proves nothing",
+            "access-bob",
+            "tab bob should have parked over tab alice -- otherwise this test proves nothing",
         )
 
-        # Tab A completes. Carries only X's id_token; the parked pair is B's.
-        done = self._resubmit(session, x_claims, "id-token-X", "ex_chosen")
+        # Tab alice completes. Carries only alice's id_token; the parked pair is B's.
+        done = self._resubmit(session, alice_claims, "id-token-alice", "alice_chosen")
         self.assertEqual(done.status_code, 302)
 
         # Signed in as X, so the proxy must not hold Y's credentials. Assert
         # the slots are absent outright, not merely "not Y's".
         self.assertEqual(
             session.get(token_session_key(ID_TOKEN_SESSION_KEY, "default")),
-            "id-token-X",
+            "id-token-alice",
         )
         self.assertNotIn(
             token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"), session
@@ -4179,39 +4179,39 @@ class TestPendingTokensBelongToOneFlow(TestCase):
         refresh token behind under the *second* flow's owner tag — waving a
         mispaired credential through the very check meant to catch it."""
         session = {}
-        x_claims = {
-            "given_name": "Ex",
+        alice_claims = {
+            "given_name": "Alice",
             "family_name": "User",
-            "email": "x@example.com",
+            "email": "a@example.com",
         }
-        y_claims = {
-            "given_name": "Why",
+        bob_claims = {
+            "given_name": "Bob",
             "family_name": "User",
-            "email": "y@example.com",
+            "email": "b@example.com",
         }
 
         self._callback(
             session,
-            x_claims,
+            alice_claims,
             {
-                "id_token": "id-token-X",
-                "access_token": "access-X",
-                "refresh_token": "refresh-X",
+                "id_token": "id-token-alice",
+                "access_token": "access-alice",
+                "refresh_token": "refresh-alice",
             },
         )
-        # Tab B: access token but no refresh token.
+        # Tab bob: access token but no refresh token.
         self._callback(
             session,
-            y_claims,
-            {"id_token": "id-token-Y", "access_token": "access-Y"},
+            bob_claims,
+            {"id_token": "id-token-bob", "access_token": "access-bob"},
         )
 
-        done = self._resubmit(session, y_claims, "id-token-Y", "why_chosen")
+        done = self._resubmit(session, bob_claims, "id-token-bob", "bob_chosen2")
         self.assertEqual(done.status_code, 302)
         self.assertNotIn(
             token_session_key(REFRESH_TOKEN_SESSION_KEY, "default"),
             session,
-            "flow Y inherited flow X's refresh token",
+            "flow bob inherited flow alice's refresh token",
         )
 
     def test_a_dropped_pair_does_not_leave_an_earlier_logins_pair_active(self):
@@ -4219,61 +4219,62 @@ class TestPendingTokensBelongToOneFlow(TestCase):
         login left in the active slots, or the new id_token ends up beside
         the old pair — the same split, reached from the other side."""
         session = {}
-        z_claims = {
-            "given_name": "Zed",
+        erin_claims = {
+            "given_name": "Erin",
             "family_name": "User",
-            "email": "zed@example.com",
+            "email": "erin@example.com",
         }
         # A completed login leaves an active pair behind.
         self._callback(
             session,
-            z_claims,
+            erin_claims,
             {
-                "id_token": "id-token-Z",
-                "access_token": "access-Z",
-                "refresh_token": "refresh-Z",
+                "id_token": "id-token-erin",
+                "access_token": "access-erin",
+                "refresh_token": "refresh-erin",
             },
         )
         self.assertEqual(
-            session[token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")], "access-Z"
+            session[token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")],
+            "access-erin",
         )
 
         # Two interleaved form flows; the second parks over the first.
-        x_claims = {
-            "given_name": "Ex",
+        alice_claims = {
+            "given_name": "Alice",
             "family_name": "User",
-            "email": "x@example.com",
+            "email": "a@example.com",
         }
-        y_claims = {
-            "given_name": "Why",
+        bob_claims = {
+            "given_name": "Bob",
             "family_name": "User",
-            "email": "y@example.com",
+            "email": "b@example.com",
         }
         self._callback(
             session,
-            x_claims,
+            alice_claims,
             {
-                "id_token": "id-token-X",
-                "access_token": "access-X",
-                "refresh_token": "refresh-X",
+                "id_token": "id-token-alice",
+                "access_token": "access-alice",
+                "refresh_token": "refresh-alice",
             },
         )
         self._callback(
             session,
-            y_claims,
+            bob_claims,
             {
-                "id_token": "id-token-Y",
-                "access_token": "access-Y",
-                "refresh_token": "refresh-Y",
+                "id_token": "id-token-bob",
+                "access_token": "access-bob",
+                "refresh_token": "refresh-bob",
             },
         )
 
-        done = self._resubmit(session, x_claims, "id-token-X", "ex_chosen")
+        done = self._resubmit(session, alice_claims, "id-token-alice", "alice_chosen")
         self.assertEqual(done.status_code, 302)
         self.assertNotIn(
             token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"),
             session,
-            "Z's pair survived beside X's id_token",
+            "erin's pair survived beside alice's id_token",
         )
 
     def test_an_abandoned_form_does_not_leave_a_pair_parked_forever(self):
@@ -4282,11 +4283,11 @@ class TestPendingTokensBelongToOneFlow(TestCase):
         session = {}
         self._callback(
             session,
-            {"given_name": "Ex", "family_name": "User", "email": "x@example.com"},
+            {"given_name": "Alice", "family_name": "User", "email": "a@example.com"},
             {
-                "id_token": "id-token-X",
-                "access_token": "access-X",
-                "refresh_token": "refresh-X",
+                "id_token": "id-token-alice",
+                "access_token": "access-alice",
+                "refresh_token": "refresh-alice",
             },
         )
         self.assertIn(
@@ -4297,14 +4298,14 @@ class TestPendingTokensBelongToOneFlow(TestCase):
         self._callback(
             session,
             {
-                "given_name": "Solo",
+                "given_name": "Carol",
                 "family_name": "User",
-                "email": "solo@example.com",
+                "email": "carol@example.com",
             },
             {
-                "id_token": "id-token-S",
-                "access_token": "access-S",
-                "refresh_token": "refresh-S",
+                "id_token": "id-token-carol",
+                "access_token": "access-carol",
+                "refresh_token": "refresh-carol",
             },
         )
 
@@ -4319,64 +4320,6 @@ class TestPendingTokensBelongToOneFlow(TestCase):
                 "abandoned pair still parked",
             )
 
-    def test_a_hard_refusal_leaves_no_credentials_at_rest(self):
-        """A refused caller never logs out, so nothing else will ever clear
-        their stash. It must not be written in the first place."""
-        session = {}
-        response = self._callback(
-            session,
-            {"email": "y@example.com"},
-            {
-                "id_token": "id-token-Y",
-                "access_token": "access-Y",
-                "refresh_token": "refresh-Y",
-            },
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            [
-                v
-                for v in session.values()
-                if "access-Y" in str(v) or "refresh-Y" in str(v)
-            ],
-            [],
-            f"refresh/access token left at rest in session: {session}",
-        )
-
-    def test_the_ordinary_form_round_trip_still_works(self):
-        """Guard: the flow pending slots exist for must keep working."""
-        session = {}
-        # A one-character local part: USE_EMAIL_USERNAME derives "s", which
-        # fails the 3-char username regex, so only {username} is missing --
-        # the form exit rather than a straight success.
-        claims = {
-            "given_name": "Solo",
-            "family_name": "User",
-            "email": "s@example.com",
-        }
-        first = self._callback(
-            session,
-            claims,
-            {
-                "id_token": "id-token-S",
-                "access_token": "access-S",
-                "refresh_token": "refresh-S",
-            },
-        )
-        self.assertEqual(first.status_code, 200)
-
-        done = self._resubmit(session, claims, "id-token-S", "solo_chosen")
-        self.assertEqual(done.status_code, 302)
-        self.assertEqual(
-            session[token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")],
-            "access-S",
-        )
-        self.assertEqual(
-            session[token_session_key(REFRESH_TOKEN_SESSION_KEY, "default")],
-            "refresh-S",
-        )
-
 
 class TestProviderAliasAnchoring(TestCase):
     """``$`` also matches before a trailing newline, so an alias validator
@@ -4388,13 +4331,6 @@ class TestProviderAliasAnchoring(TestCase):
         for alias in ("..\n", ".\n", "google\n"):
             with self.subTest(alias=alias):
                 self.assertFalse(_is_valid_provider_alias(alias))
-
-    def test_ordinary_aliases_still_pass(self):
-        from oidc.keycloak import _is_valid_provider_alias
-
-        for alias in ("google", "idp.acme.com", "MyIdP", "a..b"):
-            with self.subTest(alias=alias):
-                self.assertTrue(_is_valid_provider_alias(alias))
 
 
 @override_settings(
@@ -4482,14 +4418,14 @@ class TestCallbackDoesNotLogCredentials(TestCase):
     def test_the_uniqueness_conflict_path_does_not_log_the_id_token(self):
         # Username collides, email does not -- an email match would find the
         # existing user and log straight in, never reaching the conflict.
-        User.objects.create(username="taken", email="incumbent@example.com")
+        User.objects.create(username="alice", email="alice@example.com")
 
         response, logged = self._run(
             {
-                "given_name": "Taken",
+                "given_name": "Alice",
                 "family_name": "User",
-                "email": "newcomer@example.com",
-                "preferred_username": "taken",
+                "email": "bob@example.com",
+                "preferred_username": "alice",
             }
         )
 
@@ -4503,10 +4439,10 @@ class TestCallbackDoesNotLogCredentials(TestCase):
         newline in it would forge an extra log line."""
         response, logged = self._run(
             {
-                "given_name": "Bad",
+                "given_name": "Bob",
                 "family_name": "User",
-                "email": "bad@example.com",
-                "preferred_username": "ok_username",
+                "email": "bob@example.com",
+                "preferred_username": "bob_username",
             },
             data={
                 "username": "x\nINFO:oidc.viewsets:forged line",
@@ -4581,10 +4517,10 @@ class TestCredentialBearingSessionHardening(TestCase):
             patch(
                 "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
                 return_value={
-                    "given_name": "Rot",
+                    "given_name": "Frank",
                     "family_name": "User",
-                    "email": "rot@example.com",
-                    "preferred_username": "rotuser",
+                    "email": "frank@example.com",
+                    "preferred_username": "frankuser",
                 },
             ),
         ):
@@ -4640,12 +4576,55 @@ class TestOutboundRequestsHaveTimeouts(TestCase):
             **OPENID_CONNECT_AUTH_SERVERS,
             "default": {
                 **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "REQUEST_TIMEOUT": (1, 2),
+                "REQUEST_TIMEOUT": [5, 15],
             },
         }
     )
-    def test_the_timeout_is_configurable_per_auth_server(self):
-        self.assertEqual(OpenIDClient("default").request_timeout, (1, 2))
+    def test_a_list_from_json_or_yaml_settings_is_accepted(self):
+        """``requests`` special-cases tuple only, so the natural serialised
+        form of the documented value is the one shape that would break."""
+        self.assertEqual(OpenIDClient("default").request_timeout, (5.0, 15.0))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "REQUEST_TIMEOUT": "10",
+            },
+        }
+    )
+    def test_a_string_from_an_env_var_is_accepted(self):
+        self.assertEqual(OpenIDClient("default").request_timeout, 10.0)
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "REQUEST_TIMEOUT": None,
+            },
+        }
+    )
+    def test_none_is_refused_rather_than_restoring_an_unbounded_wait(self):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+            OpenIDClient("default")
+        self.assertIn("REQUEST_TIMEOUT", str(ctx.exception))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "REQUEST_TIMEOUT": (1, 2, 3),
+            },
+        }
+    )
+    def test_a_malformed_pair_names_the_setting(self):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+            OpenIDClient("default")
+        self.assertIn("REQUEST_TIMEOUT", str(ctx.exception))
+        self.assertIn("default", str(ctx.exception))
 
 
 class TestSessionBackendDeployCheck(TestCase):
@@ -4752,9 +4731,7 @@ class TestTokensSurviveDjangoLogin(TestCase):
         return session
 
     def test_signing_in_as_a_second_user_keeps_the_new_tokens(self):
-        incumbent = User.objects.create(
-            username="incumbent", email="incumbent@example.com"
-        )
+        incumbent = User.objects.create(username="alice", email="alice@example.com")
         session = self._session_authenticated_as(incumbent)
 
         view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
@@ -4766,10 +4743,10 @@ class TestTokensSurviveDjangoLogin(TestCase):
             patch(
                 "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
                 return_value={
-                    "given_name": "New",
-                    "family_name": "Comer",
-                    "email": "newcomer@example.com",
-                    "preferred_username": "newcomer",
+                    "given_name": "Bob",
+                    "family_name": "User",
+                    "email": "bob@example.com",
+                    "preferred_username": "bob",
                 },
             ),
         ):
@@ -4793,58 +4770,3 @@ class TestTokensSurviveDjangoLogin(TestCase):
             session.get(token_session_key(ID_TOKEN_SESSION_KEY, "default")),
             "idp-id-token",
         )
-
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "REQUEST_TIMEOUT": [5, 15],
-            },
-        }
-    )
-    def test_a_list_from_json_or_yaml_settings_is_accepted(self):
-        """``requests`` special-cases tuple only, so the natural serialised
-        form of the documented value is the one shape that would break."""
-        self.assertEqual(OpenIDClient("default").request_timeout, (5.0, 15.0))
-
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "REQUEST_TIMEOUT": "10",
-            },
-        }
-    )
-    def test_a_string_from_an_env_var_is_accepted(self):
-        self.assertEqual(OpenIDClient("default").request_timeout, 10.0)
-
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "REQUEST_TIMEOUT": None,
-            },
-        }
-    )
-    def test_none_is_refused_rather_than_restoring_an_unbounded_wait(self):
-        with self.assertRaises(ImproperlyConfigured) as ctx:
-            OpenIDClient("default")
-        self.assertIn("REQUEST_TIMEOUT", str(ctx.exception))
-
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={
-            **OPENID_CONNECT_AUTH_SERVERS,
-            "default": {
-                **OPENID_CONNECT_AUTH_SERVERS["default"],
-                "REQUEST_TIMEOUT": (1, 2, 3),
-            },
-        }
-    )
-    def test_a_malformed_pair_names_the_setting(self):
-        with self.assertRaises(ImproperlyConfigured) as ctx:
-            OpenIDClient("default")
-        self.assertIn("REQUEST_TIMEOUT", str(ctx.exception))
-        self.assertIn("default", str(ctx.exception))

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -5060,6 +5060,35 @@ class TestRouteTrailingSlashSymmetry(TestCase):
             with self.subTest(path=path):
                 resolve(path)
 
+    @override_settings(ROOT_URLCONF="tests.keycloak_urls")
+    def test_the_account_routes_accept_one_without_shadowing_each_other(self):
+        """An optional slash on a prefix route could swallow the sibling it
+        prefixes -- ``sessions/`` eating ``sessions/<id>``, ``linked-
+        accounts/`` eating ``linked-accounts/<provider>``. Each path is
+        checked against the route it must land on, not merely that it
+        resolves."""
+        expected = {
+            "/oidc/default/sessions": "openid_connect_sessions",
+            "/oidc/default/sessions/": "openid_connect_sessions",
+            "/oidc/default/sessions/abc-123": "openid_connect_sessions_revoke_one",
+            "/oidc/default/sessions/abc-123/": "openid_connect_sessions_revoke_one",
+            "/oidc/default/credentials": "openid_connect_credentials",
+            "/oidc/default/credentials/": "openid_connect_credentials",
+            "/oidc/default/linked-accounts": "openid_connect_linked_list",
+            "/oidc/default/linked-accounts/": "openid_connect_linked_list",
+            "/oidc/default/linked-accounts/ga": "openid_connect_linked_unlink",
+            "/oidc/default/linked-accounts/ga/": "openid_connect_linked_unlink",
+            "/oidc/default/linked-accounts/ga/link-url": (
+                "openid_connect_linked_link_url"
+            ),
+            "/oidc/default/linked-accounts/ga/link-url/": (
+                "openid_connect_linked_link_url"
+            ),
+        }
+        for path, url_name in expected.items():
+            with self.subTest(path=path):
+                self.assertEqual(resolve(path).url_name, url_name)
+
 
 class TestMixinOrderIsEnforced(TestCase):
     """Listing the mixin after the base viewset resolves

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1190,10 +1190,11 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(response.status_code, 502)
 
     @WITH_ACCOUNT_ENDPOINT
-    def test_proxy_does_not_disguise_our_own_bugs_as_upstream_failures(self):
-        """Pin: only transport/config errors become 502. A defect in our own
-        response handling must surface as a 500 with a traceback, not as
-        'could not reach the identity provider' pointing at Keycloak."""
+    def test_a_bug_outside_the_response_handling_is_not_reported_as_upstream(self):
+        """A 502 says "Keycloak misbehaved", which sends the investigation
+        somewhere there is nothing to find. Only the narrow window around
+        parsing and transforming a 2xx is allowed to report that; a defect
+        anywhere else must still surface as a 500 with a traceback."""
         view = KeycloakOpenIDConnectViewset.as_view({"get": "credentials_list"})
         request = self.factory.get("/")
         request.session = {"oidc_access_token:default": "t"}
@@ -1201,7 +1202,7 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         with patch.object(
             KeycloakOpenIDConnectViewset,
             "_keycloak_account_request",
-            side_effect=KeyError("bug in transform"),
+            side_effect=KeyError("bug outside the response handling"),
         ):
             with self.assertRaises(KeyError):
                 view(request, auth_server="default")
@@ -4867,12 +4868,52 @@ class TestAccountCallFailureModes(TestCase):
         response = self._get(side_effect=requests.Timeout("slow"))
         self.assertEqual(response.status_code, 502)
 
-    def test_a_non_json_body_does_not_raise(self):
-        """A fronting proxy answering with HTML must not 500 us."""
+    def test_a_non_json_2xx_body_is_a_502_not_an_empty_success(self):
+        """An ingress maintenance page or a WAF block answering 200 with
+        HTML used to reach the SPA as a successful empty result -- "you have
+        no other sessions" for a user who has several, and a "signed out
+        everywhere" that revoked nothing."""
         upstream = MagicMock(status_code=200, content=b"<html>oops</html>")
         upstream.json.side_effect = ValueError("no json")
         response = self._get(return_value=upstream)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 502)
+
+    def test_a_2xx_body_of_the_wrong_shape_is_a_502(self):
+        """The actions that forward verbatim have no transform to fail, so
+        without a declared shape a gateway's ``200 {"error": ...}`` reaches
+        the SPA as the list it was asking for."""
+        upstream = MagicMock(status_code=200, content=b'{"error":"realm gone"}')
+        upstream.json.return_value = {"error": "realm gone"}
+        response = self._get(return_value=upstream)
+        self.assertEqual(response.status_code, 502)
+
+    def test_an_empty_2xx_body_is_still_a_success(self):
+        """A declared shape must not turn "nothing to send back" into a
+        gateway error -- a 204 carries no body by definition."""
+        upstream = MagicMock(status_code=204, content=b"")
+        response = self._get(return_value=upstream)
+        self.assertEqual(response.status_code, 204)
+
+    def test_an_unparseable_error_body_is_still_reported_upstream(self):
+        """Only a 2xx has to parse. On an error status the body is echoed
+        as context, so HTML there costs nothing and must not become a 502
+        that hides the real status."""
+        upstream = MagicMock(status_code=403, content=b"<html>blocked</html>")
+        upstream.json.side_effect = ValueError("no json")
+        response = self._get(return_value=upstream)
+        self.assertEqual(response.status_code, 403)
+
+    def test_a_redirect_is_not_followed(self):
+        """Following one lands on whatever is at the other end -- usually a
+        login page answering 200 with HTML."""
+        upstream = MagicMock(status_code=200, content=b"[]")
+        upstream.json.return_value = []
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"): "t"}
+        with patch("oidc.client.requests.request", return_value=upstream) as req:
+            view(request, auth_server="default")
+        self.assertIs(req.call_args.kwargs["allow_redirects"], False)
 
     def test_an_upstream_error_is_wrapped_in_the_envelope_the_spa_reads(self):
         upstream = MagicMock(status_code=403, content=b'{"error":"forbidden"}')

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -4939,3 +4939,70 @@ class TestMixinOrderIsEnforced(TestCase):
 
     def test_the_shipped_composition_still_builds(self):
         self.assertTrue(KeycloakOpenIDConnectViewset.stash_oidc_tokens)
+
+
+@WITH_ACCOUNT_ENDPOINT
+class TestRefusalDrainsParkedTokens(TestCase):
+    """A login refused *at the username form* parks a pair on the way in.
+    ``_persist_oidc_tokens`` is the only thing that drains the pending
+    slots, and the success guard skips it on refusal -- so the pair stays.
+    A refused caller never reaches logout, so nothing else clears it."""
+
+    TOKENS = {
+        "id_token": "idp-id-token",
+        "access_token": "idp-access-token",
+        "refresh_token": "idp-refresh-token",
+    }
+    FORM_CLAIMS = {
+        "given_name": "Alice",
+        "family_name": "User",
+        "email": "a@example.com",
+    }
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _parked_session(self):
+        """Drive the first leg so the pair is parked, then hand back the
+        session mid-flow."""
+        view = RefusingViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value=dict(self.TOKENS),
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value=self.FORM_CLAIMS,
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = {}
+            response = view(request, auth_server="default")
+        self.assertEqual(response.status_code, 200, "expected the username form")
+        return request.session
+
+    def test_a_refused_resubmit_drains_the_parked_pair(self):
+        session = self._parked_session()
+        view = RefusingViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+            return_value={**self.FORM_CLAIMS, "preferred_username": "alice_chosen"},
+        ):
+            request = self.factory.post(
+                "/",
+                data={
+                    "id_token": "idp-id-token",
+                    "username": "alice_chosen",
+                    USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+                },
+            )
+            request.session = session
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            [v for v in session.values() if str(v).startswith("idp-")],
+            [],
+            f"a refused login left credentials parked: {session}",
+        )

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -41,6 +41,7 @@ from oidc.viewsets import (
     DEFAULT_USERNAME_PATTERN,
     USERNAME_FORM_MARKER_FIELD,
     USERNAME_FORM_MARKER_VALUE,
+    USERNAME_FORM_TEMPLATE,
     BaseOpenIDConnectViewset,
     RapidProOpenIDConnectViewset,
     UserModelOpenIDConnectViewset,
@@ -4070,31 +4071,39 @@ class TestPendingTokensBelongToOneFlow(TestCase):
             "erin's pair survived beside alice's id_token",
         )
 
-    def test_an_abandoned_form_does_not_leave_a_pair_parked_forever(self):
-        """Nothing else clears a parked pair for a login that was never
-        finished, so the next success in the session has to."""
-        session = {}
+    def _park(self, session, name="alice"):
+        """Leave a tab sitting on the username form. The email's local part
+        is too short to pass FIELD_VALIDATION_REGEX, which is what sends
+        USE_EMAIL_USERNAME to the form."""
         self._callback(
             session,
-            {"given_name": "Alice", "family_name": "User", "email": "a@example.com"},
+            {"given_name": name.title(), "family_name": "User", "email": "a@x.io"},
             {
-                "id_token": "id-token-alice",
-                "access_token": "access-alice",
-                "refresh_token": "refresh-alice",
+                "id_token": f"id-token-{name}",
+                "access_token": f"access-{name}",
+                "refresh_token": f"refresh-{name}",
             },
         )
         self.assertIn(
             pending_token_session_key(REFRESH_TOKEN_SESSION_KEY, "default"), session
         )
 
+    def _assert_still_parked(self, session, name):
+        self.assertEqual(
+            session.get(pending_token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")),
+            f"access-{name}",
+            f"{name}'s tab was stranded: its parked pair is gone, so completing "
+            "that login leaves the proxy answering 401 for the whole session",
+        )
+
+    def test_another_tabs_success_does_not_strand_a_tab_at_the_form(self):
+        session = {}
+        self._park(session)
+
         # A different, complete login in the same session.
         self._callback(
             session,
-            {
-                "given_name": "Carol",
-                "family_name": "User",
-                "email": "carol@example.com",
-            },
+            {"given_name": "Carol", "family_name": "User", "email": "carol@x.io"},
             {
                 "id_token": "id-token-carol",
                 "access_token": "access-carol",
@@ -4102,16 +4111,103 @@ class TestPendingTokensBelongToOneFlow(TestCase):
             },
         )
 
-        for base_key in (
-            ID_TOKEN_SESSION_KEY,
-            ACCESS_TOKEN_SESSION_KEY,
-            REFRESH_TOKEN_SESSION_KEY,
+        self._assert_still_parked(session, "alice")
+
+    def test_a_refused_login_does_not_strand_a_tab_at_the_form(self):
+        """A refusal is the likelier of the two to meet a live second tab,
+        and drains explicitly rather than as a side effect of storing."""
+        session = {}
+        self._park(session)
+
+        view = RefusingViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value={
+                    "id_token": "id-token-carol",
+                    "access_token": "access-carol",
+                },
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value={
+                    "given_name": "Carol",
+                    "family_name": "User",
+                    "email": "carol@x.io",
+                    "preferred_username": "carol",
+                },
+            ),
         ):
-            self.assertNotIn(
-                pending_token_session_key(base_key, "default"),
-                session,
-                "abandoned pair still parked",
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = session
+            self.assertEqual(view(request, auth_server="default").status_code, 403)
+
+        self._assert_still_parked(session, "alice")
+
+    def test_a_resubmit_that_fails_takes_its_own_pair_back(self):
+        """Storing the pair is what used to drain it, so every exit that
+        stores nothing left a refresh token at rest for someone who never
+        signed in and so never reaches logout. Here the id_token no longer
+        decodes; an expired PKCE entry and AUTO_CREATE_USER=False are the
+        same shape."""
+        session = {}
+        self._park(session)
+
+        view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+            side_effect=jwt.DecodeError("not a token"),
+        ):
+            request = self.factory.post(
+                "/",
+                data={
+                    "id_token": "id-token-alice",
+                    "username": "alice_chosen",
+                    USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+                },
             )
+            request.session = session
+            self.assertEqual(view(request, auth_server="default").status_code, 401)
+
+        self.assertEqual(
+            [k for k in session if k.endswith(":pending")],
+            [],
+            "a failed resubmit left its own pair parked",
+        )
+
+    def test_a_second_try_at_the_username_keeps_the_pair(self):
+        """Picking a username that is taken re-renders the form. That exit
+        has to keep the pair parked -- it is the one exit that does -- or
+        the user completes login on their second try with no pair, and the
+        account proxy 401s for the rest of the session."""
+        session = {}
+        self._park(session)
+        User.objects.create(username="taken_name", email="someone@x.io")
+        claims = {"given_name": "Alice", "family_name": "User", "email": "a@x.io"}
+
+        again = self._resubmit(session, claims, "id-token-alice", "taken_name")
+        self.assertEqual(again.template_name, USERNAME_FORM_TEMPLATE)
+
+        done = self._resubmit(session, claims, "id-token-alice", "alice_chosen")
+        self.assertEqual(done.status_code, 302)
+        self.assertEqual(
+            session.get(token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")),
+            "access-alice",
+        )
+
+    def test_logout_clears_a_pair_abandoned_at_the_form(self):
+        """Nothing can tell an abandoned pair from one whose tab is still on
+        the form, so the parked pair outlives the flow. Logout is what
+        collects it."""
+        session = {}
+        self._park(session)
+
+        logout = KeycloakOpenIDConnectViewset.as_view({"get": "logout"})
+        request = self.factory.get("/")
+        request.session = session
+        logout(request, auth_server="default")
+
+        self.assertEqual([k for k in session if k.endswith(":pending")], [])
 
 
 class TestProviderAliasAnchoring(TestCase):

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -5006,3 +5006,36 @@ class TestRefusalDrainsParkedTokens(TestCase):
             [],
             f"a refused login left credentials parked: {session}",
         )
+
+
+@WITH_ACCOUNT_ENDPOINT
+class TestUnexpectedUpstreamShapeIsNotA500(TestCase):
+    """``transform`` normalises Keycloak's body. A 2xx carrying something
+    else -- a gateway answering 200 with an error object, or an upstream
+    shape change -- must not surface as a traceback."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _sessions_with(self, body):
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "sessions_list"})
+        request = self.factory.get("/")
+        request.session = {token_session_key(ACCESS_TOKEN_SESSION_KEY, "default"): "t"}
+        upstream = MagicMock(status_code=200, content=b"x")
+        upstream.json.return_value = body
+        with patch("oidc.client.requests.request", return_value=upstream):
+            return view(request, auth_server="default")
+
+    def test_a_json_error_object_under_a_200_is_a_502(self):
+        response = self._sessions_with({"error": "realm not found"})
+        self.assertEqual(response.status_code, 502)
+
+    def test_an_unexpected_device_shape_is_a_502(self):
+        response = self._sessions_with([{"os": "mac", "sessions": {"id": "a"}}])
+        self.assertEqual(response.status_code, 502)
+
+    def test_the_expected_shape_still_flattens(self):
+        response = self._sessions_with(
+            [{"os": "mac", "sessions": [{"id": "a", "current": True}]}]
+        )
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -4887,6 +4887,16 @@ class TestAccountCallFailureModes(TestCase):
         response = self._get(return_value=upstream)
         self.assertEqual(response.status_code, 502)
 
+    @WITH_DEFAULT_SETTINGS
+    def test_a_caller_with_no_session_is_not_told_about_the_configuration(self):
+        """WITH_DEFAULT_SETTINGS has no ACCOUNT_ENDPOINT. Answering 503
+        first tells an anonymous caller which deployments have the proxy
+        turned on; the session check has to come first."""
+        view = KeycloakOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {}
+        self.assertEqual(view(request, auth_server="default").status_code, 401)
+
     def test_an_empty_2xx_body_is_still_a_success(self):
         """A declared shape must not turn "nothing to send back" into a
         gateway error -- a 204 carries no body by definition."""

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -4706,3 +4706,145 @@ class TestSessionBackendDeployCheck(TestCase):
         """Not this check's job to report a broken VIEWSET_CLASS, and it
         must not mask it by raising from here."""
         self.assertEqual(check_session_backend_can_hold_tokens(None), [])
+
+
+@override_settings(
+    OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
+    OPENID_CONNECT_VIEWSET_CONFIG={
+        **OPENID_CONNECT_VIEWSET_CONFIG,
+        "USE_AUTH_BACKEND": True,
+    },
+)
+class TestTokensSurviveDjangoLogin(TestCase):
+    """Django's ``login()`` flushes the session when a *different* user was
+    already authenticated in it. Anything written before that call is gone.
+
+    Reachable without any misuse: a browser still holding a session for one
+    account runs the OIDC flow and picks another at the IdP. The sign-in
+    succeeds, so nothing looks wrong -- but the proxy answers 401 to every
+    call and logout has no ``id_token_hint``, and only a full sign-out
+    clears it. ``USE_AUTH_BACKEND`` is off in the library default but on in
+    the deployment this proxy was built for.
+    """
+
+    TOKENS = {
+        "id_token": "idp-id-token",
+        "access_token": "idp-access-token",
+        "refresh_token": "idp-refresh-token",
+    }
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def _session_authenticated_as(self, user):
+        from django.contrib.auth import (
+            BACKEND_SESSION_KEY,
+            HASH_SESSION_KEY,
+            SESSION_KEY,
+        )
+        from django.contrib.sessions.backends.db import SessionStore
+
+        session = SessionStore()
+        session[SESSION_KEY] = str(user.pk)
+        session[BACKEND_SESSION_KEY] = "django.contrib.auth.backends.ModelBackend"
+        session[HASH_SESSION_KEY] = user.get_session_auth_hash()
+        session.save()
+        return session
+
+    def test_signing_in_as_a_second_user_keeps_the_new_tokens(self):
+        incumbent = User.objects.create(
+            username="incumbent", email="incumbent@example.com"
+        )
+        session = self._session_authenticated_as(incumbent)
+
+        view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+        with (
+            patch(
+                "oidc.viewsets.OpenIDClient.retrieve_tokens_using_auth_code",
+                return_value=dict(self.TOKENS),
+            ),
+            patch(
+                "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+                return_value={
+                    "given_name": "New",
+                    "family_name": "Comer",
+                    "email": "newcomer@example.com",
+                    "preferred_username": "newcomer",
+                },
+            ),
+        ):
+            request = self.factory.post("/", data={"code": "auth-code"})
+            request.session = session
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            session.get(token_session_key(ACCESS_TOKEN_SESSION_KEY, "default")),
+            "idp-access-token",
+            "login() flushed the session after the tokens were written",
+        )
+        self.assertEqual(
+            session.get(token_session_key(REFRESH_TOKEN_SESSION_KEY, "default")),
+            "idp-refresh-token",
+        )
+        # Without this, logout falls back to a bare end-session URL and
+        # Keycloak shows its confirm screen.
+        self.assertEqual(
+            session.get(token_session_key(ID_TOKEN_SESSION_KEY, "default")),
+            "idp-id-token",
+        )
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "REQUEST_TIMEOUT": [5, 15],
+            },
+        }
+    )
+    def test_a_list_from_json_or_yaml_settings_is_accepted(self):
+        """``requests`` special-cases tuple only, so the natural serialised
+        form of the documented value is the one shape that would break."""
+        self.assertEqual(OpenIDClient("default").request_timeout, (5.0, 15.0))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "REQUEST_TIMEOUT": "10",
+            },
+        }
+    )
+    def test_a_string_from_an_env_var_is_accepted(self):
+        self.assertEqual(OpenIDClient("default").request_timeout, 10.0)
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "REQUEST_TIMEOUT": None,
+            },
+        }
+    )
+    def test_none_is_refused_rather_than_restoring_an_unbounded_wait(self):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+            OpenIDClient("default")
+        self.assertIn("REQUEST_TIMEOUT", str(ctx.exception))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "REQUEST_TIMEOUT": (1, 2, 3),
+            },
+        }
+    )
+    def test_a_malformed_pair_names_the_setting(self):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+            OpenIDClient("default")
+        self.assertIn("REQUEST_TIMEOUT", str(ctx.exception))
+        self.assertIn("default", str(ctx.exception))

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -5039,3 +5039,45 @@ class TestUnexpectedUpstreamShapeIsNotA500(TestCase):
             [{"os": "mac", "sessions": [{"id": "a", "current": True}]}]
         )
         self.assertEqual(response.status_code, 200)
+
+
+class TestDeployCheckComparesRoutesNotNames(TestCase):
+    """E002 originally compared action *names*, so any re-declaration passed
+    -- including the one its own hint described. These are the shapes that
+    keep the name and lose the route."""
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.NarrowedRedeclareViewset",
+        }
+    )
+    def test_dropping_a_mapping_companion_is_reported(self):
+        """`@sessions_list.mapping.delete` is how sessions_revoke_others is
+        routed; a fresh decorator replaces the mapper and DELETE /sessions
+        becomes a 405."""
+        errors = check_actions_survive_subclassing(None)
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+        self.assertIn("sessions_list", errors[0].msg)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.RenamedRouteViewset",
+        }
+    )
+    def test_a_changed_url_name_is_reported(self):
+        """The library itself reverses openid_connect_login on the callback
+        error path, so losing the name turns that page into a 500."""
+        errors = check_actions_survive_subclassing(None)
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+        self.assertIn("login", errors[0].msg)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.RedeclaredOverrideViewset",
+        }
+    )
+    def test_a_faithful_redeclaration_still_passes(self):
+        self.assertEqual(check_actions_survive_subclassing(None), [])

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -4197,6 +4197,32 @@ class TestPendingTokensBelongToOneFlow(TestCase):
             "access-alice",
         )
 
+    def test_a_callback_that_raises_still_gives_the_pair_up(self):
+        """An id_token shape this library has no handler for raises past
+        every ``except`` and becomes a 500. That is an exit too, and the
+        caller behind it never signed in, so never reaches logout."""
+        session = {}
+        self._park(session)
+
+        view = KeycloakOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
+            side_effect=TokenVerificationFailed("no email claim"),
+        ):
+            request = self.factory.post(
+                "/",
+                data={
+                    "id_token": "id-token-alice",
+                    "username": "alice_chosen",
+                    USERNAME_FORM_MARKER_FIELD: USERNAME_FORM_MARKER_VALUE,
+                },
+            )
+            request.session = session
+            with self.assertRaises(TokenVerificationFailed):
+                view(request, auth_server="default")
+
+        self.assertEqual([k for k in session if k.endswith(":pending")], [])
+
     def test_logout_clears_a_pair_abandoned_at_the_form(self):
         """Nothing can tell an abandoned pair from one whose tab is still on
         the form, so the parked pair outlives the flow. Logout is what
@@ -5216,9 +5242,9 @@ class TestParkedPairSurvivesTheLoginFlush(TestCase):
 @WITH_ACCOUNT_ENDPOINT
 class TestRefusalDrainsParkedTokens(TestCase):
     """A login refused *at the username form* parks a pair on the way in.
-    Storing the tokens is what drains the pending slots, and the success
-    guard skips it on refusal -- so the pair stays. A refused caller never
-    reaches logout, so nothing else clears it."""
+    Nothing on the refusal path stores tokens, so nothing on it would clear
+    them either -- and a refused caller never reaches logout. ``callback``
+    takes the pair back on the way out for exactly this reason."""
 
     TOKENS = {
         "id_token": "idp-id-token",

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -25,7 +25,7 @@ from oidc.checks import (
 )
 from oidc.keycloak import _sid_from_id_token
 from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
-from oidc.keycloak import KeycloakOpenIDConnectViewset
+from oidc.keycloak import KeycloakAccountMixin, KeycloakOpenIDConnectViewset
 from oidc.permissions import IsCsrfSafeAccountRequest, get_account_request_header
 from oidc.urls import get_viewset_class
 from oidc.utils import (
@@ -4883,3 +4883,32 @@ class TestRemainingTokenLifecycleGuards(TestCase):
         with patch("oidc.client.requests.get", return_value=upstream) as mock_get:
             client._retrieve_jwks_related_to_kid("some-kid")
         self.assertIsNotNone(mock_get.call_args.kwargs.get("timeout"))
+
+
+class TestRouteTrailingSlashSymmetry(TestCase):
+    """The router anchors patterns, so each action opts back into an
+    optional trailing slash. ``session`` originally did not, while the other
+    three did -- a configured probe URL ending in ``/`` then 404s and the
+    SPA silently falls through to a full IdP redirect."""
+
+    @override_settings(ROOT_URLCONF="tests.keycloak_urls")
+    def test_all_four_base_routes_accept_a_trailing_slash(self):
+        for path in (
+            "/oidc/default/login/",
+            "/oidc/default/logout/",
+            "/oidc/default/callback/",
+            "/oidc/default/session/",
+        ):
+            with self.subTest(path=path):
+                resolve(path)  # raises Resolver404 if the route is anchored
+
+    @override_settings(ROOT_URLCONF="tests.keycloak_urls")
+    def test_they_all_resolve_without_one_too(self):
+        for path in (
+            "/oidc/default/login",
+            "/oidc/default/logout",
+            "/oidc/default/callback",
+            "/oidc/default/session",
+        ):
+            with self.subTest(path=path):
+                resolve(path)


### PR DESCRIPTION
## Summary

Keycloak Account REST proxy: cookie-identified endpoints under `/oidc/<auth_server>/` backing the SPA's Account tab — sessions, linked accounts, credentials. Read-and-revoke only; there is no profile-update endpoint.

Opt-in via `VIEWSET_CLASS`: the actions live in `KeycloakAccountMixin`, so without the mixin the routes are not generated at all.

All methods are gated by `IsCsrfSafeAccountRequest` — every request's `Origin` must be absent or in the `LOGIN_REDIRECT_ALLOWED_HOSTS` trusted set, and unsafe methods must also carry `X-Ona-Account-Request`. Reads deliberately skip the header: markup GETs can't read a JSON response, so it adds nothing the Origin check doesn't.

## Session tokens

The proxy needs the access/refresh pair the callback would otherwise drop, which raises the stakes on the session:

- **Keyed per auth server** (`oidc_access_token:<auth_server>`). The URL selects the provider, so a global key would let a request to provider B spend provider A's tokens against B's endpoints.
- **Written only on the success exit**, and only after Django's `login()` — which flushes the session when a different user was authenticated in it.
- **Cleared on logout**, including pending and pre-namespacing keys.
- **Session id rotated**, since `login()` only runs under `USE_AUTH_BACKEND`.
- **Server-side `SESSION_ENGINE` required**, enforced by a deploy check (`oidc.E001`) plus a request-time backstop.

When the claims carry no usable username the callback returns an entry form and the browser re-POSTs only the `id_token`, so the pair is parked in `<name>:<auth_server>:pending`, tagged with its owning id_token — one session can be running two logins at once. Rendering that form is the only callback exit allowed to leave a pair parked; every other exit — including a `500` — takes back the one its own id_token owns, and only that one, so a second tab still sitting on the form is neither stranded nor able to donate its tokens. On the form path the pair is taken back into locals *before* `generate_successful_response`, since under `USE_AUTH_BACKEND` that runs Django's `login()`, whose flush would otherwise take the session's parked slots with it.

## Configuration

- `ACCOUNT_ENDPOINT` (unset → 503 for a caller with a session, 401 for one without).
- `RESPONSE_TYPE: "code"` **plus** `TOKEN_ENDPOINT`. The repo default is `"id_token"`, with which login works but nothing is stashed and every proxy call 401s. Hybrid also yields no access token.
- Cross-origin SPAs: exact netloc (host **and** port) in `LOGIN_REDIRECT_ALLOWED_HOSTS`.
- Optional `REQUEST_TIMEOUT`, default `(5, 15)`.

## Backwards compatibility

- Session keys renamed to the per-provider form, no fallback read — live sessions take one 401 and sign in again.
- Proxy actions moved from the base viewset into `KeycloakAccountMixin`; consumers with their own subclass must mix it in (onaio/onadata#3185).
- The `account` profile-update action is removed.
- `Origin` now applies to reads, so a cross-origin deployment allowed only via `CORS_ALLOWED_ORIGINS` must also be in `LOGIN_REDIRECT_ALLOWED_HOSTS`.
- A 2xx from the account endpoint that is not JSON, or not the shape the action forwards, is now a 502 rather than an empty success. Anything answering 200 with an HTML maintenance or login page used to reach the SPA as "you have no other sessions". Redirects are no longer followed on either the account or the refresh call, and a 3xx that arrives anyway is a 502 rather than a redirect re-emitted from our own origin without a `Location`.
- `str_to_bool` now reads `"false"`, `"0"`, `""`, `"no"` and `"off"` as false. Only the exact literal `"False"` used to be, so the spelling `os.getenv` hands you turned switches *on*: `AUTO_CREATE_USER` created the users it was set to refuse, `USE_SSO_COOKIE` issued the identity cookie anyway, and the admin's user-import screen enabled itself.
- The package now ships a plain `base.html`. The username form and the error page extend it, and a project without one of its own got `TemplateDoesNotExist` — a bare 500 on both. A project's own still wins from `TEMPLATES["DIRS"]` or from an app listed before `oidc`.
- The wheel no longer installs a top-level `tests` package into site-packages.
- `oidc.E002` now compares an override's `detail` flag and its `permission_classes`/`authentication_classes`/`renderer_classes` as well as its path, name and verbs — a re-declaration that omits them falls back to `AllowAny` and silently drops the account proxy's CSRF/Origin gate. Adding to them is fine; only widening is reported.

No version bump — this repo bumps in its own PR. The next release should be a minor at least.

## Test plan

- [x] `python manage.py test tests` — 294 tests; every commit on the branch checked out and run individually, so `git bisect` works across it
- [x] flake8 + black + isort clean; `manage.py check` clean
- [x] Guards mutation-tested: removing the pending-pair owner check, the drain on a non-form exit, either non-atomic write, the session rotation, the cookie-session refusal, a timeout, the timeout coercion, the persist ordering, the id_token log fix, the unparseable-2xx refusal, the declared body shape, `allow_redirects=False`, the session-before-config ordering, an optional trailing slash, taking the pair before `login()` rather than after, the `finally` that survives a raise, the router's dynamic-only name stripping, the defensive body read in the callback's `finally`, the form-response marker, the guarded-kwarg presence check, `AND`-only permission flattening, or any one of E002's six comparisons each fails a test
- [x] Smoke-tested against Keycloak: sessions incl. the 409 guard, linked accounts, credentials with TOTP enrolled
- [ ] Confirm `LOGIN_REDIRECT_ALLOWED_HOSTS` contains the SPA's exact netloc in stage/prod before merge — a missing entry now 403s reads

## Follow-up (not in this PR)

A separate security PR is warranted for pre-existing issues found while reviewing this one, none reachable through the proxy: `state`/`nonce` not bound to the initiating browser, the nonce never consumed, `_get_user_group_defaults` mutating global settings, `str_to_bool` failing open on `"false"`, admin directory search gated on `is_staff` alone, and no algorithm allowlist on id_token verification.

Also left alone deliberately: `callback` does not catch `TokenVerificationFailed`, so an IdP issuing an id_token with no `email`/`emails` and no `at_hash` 500s on every login — pre-existing, and its credential-at-rest half is closed by the `finally` above. The flattened session row omits Keycloak's `device`, `osVersion`, `mobile` and `expires`; the SPA's `SessionRow` consumes none of them, so they are not forwarded.

