### PR TITLE
fix(oidc): honor `next` when USE_NONCES=False

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ Validation runs Django's `url_has_allowed_host_and_scheme`, so
 `javascript:` / `data:` schemes and protocol-relative `//evil` URLs
 are rejected. Under HTTPS, `http://` redirects are also rejected.
 
+`next` is honored regardless of `USE_NONCES`. When the caller supplies
+`next`, ona-oidc allocates a nonce and caches the validated redirect
+target under it for the duration of the auth round-trip; the callback
+restores the value from cache and uses it as the post-auth redirect.
+With `USE_NONCES=False` the nonce is still emitted purely as the cache
+key — no IdP-side nonce verification is performed.
+
 4. (Optional) If you'd like to use the default OpenID Connect Viewset register the urls located in `oidc.urls`.
 
 ```python

--- a/oidc/client.py
+++ b/oidc/client.py
@@ -285,18 +285,26 @@ class OpenIDClient:
         decoded_token = jwt.decode(
             id_token, public_key, audience=[self.client_id], algorithms=alg
         )
+        # ``login()`` writes ``{auth_server, redirect_after}`` under the
+        # nonce whenever the caller supplied a ``next``, even when
+        # ``USE_NONCES`` is False (line 405: ``self.cache_nonces or
+        # redirect_after``). Read the cache here under the same
+        # condition so the post-auth redirect honors ``next`` regardless
+        # of nonce verification — otherwise the cached entry would
+        # silently expire unread when ``USE_NONCES`` is False (#116).
+        nonce = decoded_token.get("nonce")
+        cached_data = cache.get(nonce) if nonce else None
         if self.cache_nonces:
             # Verify that the cached nonce is present and that
             # the provider the nonce was initiated for, is the same
             # provider returning it
-            nonce = decoded_token.get("nonce")
             if not nonce:
                 raise NonceVerificationFailed(
                     "Failed to verify login request. Missing nonce value"
                 )
-            cached_data = cache.get(nonce)
             if not cached_data or self.auth_server != cached_data.get("auth_server"):
                 raise NonceVerificationFailed("Failed to verify returned nonce value")
+        if cached_data and cached_data.get("redirect_after"):
             decoded_token[REDIRECT_AFTER_AUTH] = cached_data.get("redirect_after")
         return decoded_token
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,12 @@ from django.test.utils import override_settings
 import jwt
 import requests
 
-from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
+from oidc.client import (
+    REDIRECT_AFTER_AUTH,
+    OpenIDClient,
+    TokenVerificationFailed,
+    state_cache_key,
+)
 
 OPENID_CONNECT_AUTH_SERVERS = {
     "default": {
@@ -756,3 +761,99 @@ class OpenIDClientTestCase(TestCase):
             client.tokens_to_user_info(decoded_id_token, id_token, access_token)
 
         self.assertIn("Failed to validate access token", str(context.exception))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            "default": {
+                "AUTHORIZATION_ENDPOINT": (
+                    "https://example.com/oauth2/v2.0/authorize"
+                ),
+                "CLIENT_ID": "client",
+                "JWKS_ENDPOINT": "https://example.com/discovery/v2.0/keys",
+                "SCOPE": "openid profile",
+                "TOKEN_ENDPOINT": "https://example.com/oauth2/v2.0/token",
+                "END_SESSION_ENDPOINT": "http://localhost:3000",
+                "REDIRECT_URI": "http://localhost:8000/oidc/msft/callback",
+                "RESPONSE_TYPE": "code",
+                "RESPONSE_MODE": "form_post",
+                "USE_NONCES": False,
+                "NONCE_CACHE_TIMEOUT": 600,
+            }
+        }
+    )
+    @patch("oidc.client.RSAAlgorithm.from_jwk")
+    @patch("oidc.client.jwt.decode")
+    @patch("oidc.client.jwt.get_unverified_header")
+    @patch.object(OpenIDClient, "_retrieve_jwks_related_to_kid")
+    @patch.object(secrets, "token_urlsafe")
+    def test_next_round_trip_with_use_nonces_false(
+        self,
+        mock_token_urlsafe,
+        mock_jwks,
+        mock_get_header,
+        mock_jwt_decode,
+        _mock_from_jwk,
+    ):
+        """Regression test for #116: with ``USE_NONCES=False``, a
+        ``next`` value passed to ``login()`` is restored on the
+        callback so the post-auth redirect honors it.
+
+        Before the fix, ``verify_and_decode_id_token`` only restored
+        ``REDIRECT_AFTER_AUTH`` from cache inside the
+        ``cache_nonces=True`` branch, so the value was silently
+        dropped when nonces were disabled.
+        """
+        mock_token_urlsafe.return_value = "n1"
+        mock_jwks.return_value = {"kty": "RSA"}
+        mock_get_header.return_value = {"kid": "k1", "alg": "RS256"}
+        mock_jwt_decode.return_value = {"sub": "1", "nonce": "n1"}
+
+        client = OpenIDClient("default")
+        client.login(redirect_after="/dashboard")
+
+        decoded = client.verify_and_decode_id_token("h.p.s")
+
+        self.assertEqual(decoded[REDIRECT_AFTER_AUTH], "/dashboard")
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            "default": {
+                "AUTHORIZATION_ENDPOINT": (
+                    "https://example.com/oauth2/v2.0/authorize"
+                ),
+                "CLIENT_ID": "client",
+                "JWKS_ENDPOINT": "https://example.com/discovery/v2.0/keys",
+                "SCOPE": "openid profile",
+                "TOKEN_ENDPOINT": "https://example.com/oauth2/v2.0/token",
+                "END_SESSION_ENDPOINT": "http://localhost:3000",
+                "REDIRECT_URI": "http://localhost:8000/oidc/msft/callback",
+                "RESPONSE_TYPE": "code",
+                "RESPONSE_MODE": "form_post",
+                "USE_NONCES": False,
+                "NONCE_CACHE_TIMEOUT": 600,
+            }
+        }
+    )
+    @patch("oidc.client.RSAAlgorithm.from_jwk")
+    @patch("oidc.client.jwt.decode")
+    @patch("oidc.client.jwt.get_unverified_header")
+    @patch.object(OpenIDClient, "_retrieve_jwks_related_to_kid")
+    def test_no_next_with_use_nonces_false_does_not_set_redirect_after(
+        self,
+        mock_jwks,
+        mock_get_header,
+        mock_jwt_decode,
+        _mock_from_jwk,
+    ):
+        """``USE_NONCES=False`` and no ``next``: nothing is cached,
+        ``verify_and_decode_id_token`` does not invent a redirect
+        target. ``REDIRECT_AFTER_AUTH`` is absent from the decoded
+        token so the viewset falls back to the configured default."""
+        mock_jwks.return_value = {"kty": "RSA"}
+        mock_get_header.return_value = {"kid": "k1", "alg": "RS256"}
+        mock_jwt_decode.return_value = {"sub": "1"}
+
+        client = OpenIDClient("default")
+        decoded = client.verify_and_decode_id_token("h.p.s")
+
+        self.assertNotIn(REDIRECT_AFTER_AUTH, decoded)


### PR DESCRIPTION
Closes #116.

## Summary

`OpenIDClient.login()` already caches `redirect_after` under a fresh nonce whenever the caller supplies `next`, even with `USE_NONCES=False` (see `client.py` line 405: `self.cache_nonces or redirect_after`). The asymmetry was on the read side — `verify_and_decode_id_token()` only restored `REDIRECT_AFTER_AUTH` from cache inside its `cache_nonces=True` branch, so the cached target was silently dropped on every callback when nonces were disabled, and the post-auth redirect fell back to the configured `REDIRECT_AFTER_AUTH` default.

## Fix

Lift the cache lookup + restoration out of the `cache_nonces` branch so it mirrors what `login()` writes:

- Read the cache whenever the decoded id_token carries a nonce.
- Keep the existing nonce-verification semantics under `cache_nonces=True` (missing nonce → `NonceVerificationFailed`; auth_server mismatch → `NonceVerificationFailed`).
- Restore `REDIRECT_AFTER_AUTH` whenever the cached entry has one, regardless of `cache_nonces`.

The contract becomes option 1 from the issue: `next` works regardless of `USE_NONCES`. With `USE_NONCES=False` and no `next`, nothing changes — no nonce is emitted, no cache lookup happens, no `REDIRECT_AFTER_AUTH` is set, and the viewset falls back to the configured default. The "silently cache redirect state that will never be consumed" concern from the issue is also resolved: with the fix, the cached entry is now consumed in both `USE_NONCES` modes.

## Tests

Two new tests in `tests/test_client.py`:

- **`test_next_round_trip_with_use_nonces_false`** — exercises `login(redirect_after=…)` → `verify_and_decode_id_token()` end-to-end at the client level with `USE_NONCES=False`, asserting the round-trip preserves `next`. This is the regression test for #116; it would fail on `main` because the pre-fix code would not set `REDIRECT_AFTER_AUTH` on the decoded token.
- **`test_no_next_with_use_nonces_false_does_not_set_redirect_after`** — pins the no-`next` path so the fix doesn't invent a redirect target.

End-to-end coverage is maintained via composition: existing viewset tests (e.g. `test_create_non_existing_user` in `tests/test_viewsets.py`) already prove the decoded `REDIRECT_AFTER_AUTH` flows through to `response.url` — combined with the new client tests, the full login → callback → redirect flow is covered for both `USE_NONCES` modes.

## Docs

README clarifies the contract in the existing "Validating the post-authentication redirect target (`next`)" section: `next` is honored regardless of `USE_NONCES`; with `USE_NONCES=False` the nonce is emitted purely as the cache key, no IdP-side nonce verification.

## Files

```
README.md            | +7 / -0
oidc/client.py       | +10 / -2
tests/test_client.py | +102 / -1
```

## Test plan

- [ ] `python manage.py test tests.test_client` passes (existing + 2 new tests)
- [ ] flake8 + black clean
- [ ] Manual: with `USE_NONCES=False`, `GET /oidc/<server>/login?next=/dashboard` → complete auth → final redirect lands on `/dashboard` (not the configured `REDIRECT_AFTER_AUTH` default)