### PR TITLE
fix: map SSO logins to the correct account by unique username

### DIFF
--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -7,7 +7,6 @@ from django.http import HttpRequest
 from django.utils.http import url_has_allowed_host_and_scheme
 
 import jwt
-from jwt.exceptions import InvalidSignatureError
 
 import oidc.settings as default
 
@@ -44,7 +43,10 @@ def authenticate_sso(request, unique_user_field: Optional[str] = None):
         )
         if user and user.is_active:
             return (user, True)
-    except InvalidSignatureError:
+    except jwt.PyJWTError:
+        # Any malformed/expired/badly-signed token is treated as
+        # unauthenticated rather than propagating as a 500. Previously only
+        # ``InvalidSignatureError`` was caught, so e.g. an expired token raised.
         pass
     return None
 

--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -12,10 +12,18 @@ from jwt.exceptions import InvalidSignatureError
 import oidc.settings as default
 
 
-def authenticate_sso(request, unique_user_field: str = "email"):
+def authenticate_sso(request, unique_user_field: Optional[str] = None):
     config = getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", {})
     secret_key = config.get("JWT_SECRET_KEY", "")
     algorithm = config.get("JWT_ALGORITHM", "HS256")
+    # Resolve the lookup field from the same setting the SSO cookie is built
+    # with (see ``OpenIDConnectBaseViewset.generate_successful_response``) so
+    # the cookie producer and this consumer can never drift apart. ``username``
+    # is unique on the user model; ``email`` (the historical default) is not,
+    # which let ``.first()`` resolve to an arbitrary account whenever two users
+    # shared an email.
+    if unique_user_field is None:
+        unique_user_field = config.get("SSO_COOKIE_DATA", "email")
     sso = request.META.get("HTTP_SSO") or request.COOKIES.get("SSO")
     if not sso:
         return None
@@ -23,6 +31,12 @@ def authenticate_sso(request, unique_user_field: str = "email"):
     try:
         jwt_payload = jwt.decode(sso, secret_key, algorithms=[algorithm])
         unique_user_value = jwt_payload.get(unique_user_field)
+        # A cookie that doesn't carry the configured claim (e.g. a legacy
+        # ``{"email": ...}`` cookie after switching to ``username``) must not
+        # fall through to ``filter(field=None)``, which would otherwise match
+        # any user whose column is NULL.
+        if unique_user_value is None:
+            return None
         user = (
             get_user_model()
             .objects.filter(**{unique_user_field: unique_user_value})

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -454,6 +454,45 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         if state:
             cache.delete(state_cache_key(state))
 
+    @staticmethod
+    def _resolve_matched_user(matched_users, claimed_username):
+        """Resolve the single account a login should attach to.
+
+        ``email`` is not unique on the user model, so an email lookup can
+        return several accounts. ``username`` *is* unique, so the
+        ``preferred_username`` claim is authoritative: when it matches one of
+        the email-matched accounts we attach to exactly that account. We bind
+        by email alone only when the match is unambiguous (a single account).
+        When several accounts share the email and none matches the username
+        claim we return ``None`` so the caller fails closed (auto-create or a
+        401) instead of binding the session to an arbitrary account.
+
+        :param matched_users: queryset of accounts matched by email
+        :param claimed_username: the unique username carried by the token, or
+            ``None`` when the claim is absent
+        :return: the resolved user, or ``None`` when no unambiguous match
+        """
+        # Materialize once; resolve the rest in memory rather than issuing a
+        # fresh query for each of exists()/count()/filter()/first().
+        matched = list(matched_users)
+        if not matched:
+            return None
+
+        if claimed_username:
+            # Exact match (not ``__iexact`` like the email lookup) is
+            # deliberate: ``username`` is unique, so at most one account can
+            # match exactly. A case-insensitive compare could match two
+            # case-variant usernames that share the email and reintroduce the
+            # very ambiguity this method exists to prevent.
+            for candidate in matched:
+                if candidate.username == claimed_username:
+                    return candidate
+
+        if len(matched) == 1:
+            return matched[0]
+
+        return None
+
     @action(methods=["POST", "GET"], detail=False)
     def callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa
         auth_server = kwargs.get("auth_server")
@@ -583,20 +622,10 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                         user_data["email"] = user_data["emails"][0]
                         matched_users = self.user_model.objects.filter(q_objects)
 
-                    if matched_users is not None and matched_users.exists():
-                        # Email is not unique on the user model, so a lookup can
-                        # return several accounts. When it does, disambiguate with
-                        # the unique username carried by the ``preferred_username``
-                        # claim so we attach to the exact account that logged in
-                        # rather than letting ``.get()`` raise
-                        # ``MultipleObjectsReturned`` or picking one arbitrarily.
-                        claimed_username = user_data.get("username")
-                        if matched_users.count() > 1 and claimed_username:
-                            user = matched_users.filter(
-                                username=claimed_username
-                            ).first()
-                        if not user:
-                            user = matched_users.first()
+                    if matched_users is not None:
+                        user = self._resolve_matched_user(
+                            matched_users, user_data.get("username")
+                        )
 
                     if not user and not self.auto_create_user:
                         self._clear_login_states(server_response)

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -341,27 +341,33 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             login(request, user, backend=self.auth_backend)
 
         if self.use_sso:
-            # Key the cookie claim by the configured field name (``self.sso_cookie``
-            # == ``SSO_COOKIE_DATA``) rather than a hardcoded ``"email"``. The old
-            # hardcoded key stored e.g. the username *value* under an ``"email"``
-            # key, so ``authenticate_sso`` could only ever look users up by email —
-            # ambiguous when accounts share one. Producer and consumer now agree on
-            # the same field, defaulting to ``email`` for unchanged deployments.
-            sso_cookie = jwt.encode(
-                {self.sso_cookie: getattr(user, self.sso_cookie, None)},
-                config.get("JWT_SECRET_KEY"),
-                config.get("JWT_ALGORITHM"),
-            )
-            response.set_cookie(
-                SSO_COOKIE_NAME,
-                value=sso_cookie,
-                max_age=self.cookie_max_age,
-                domain=self.cookie_domain,
-                path=self.cookie_path,
-                httponly=self.cookie_httponly,
-                secure=self._resolve_cookie_secure(),
-                samesite=self.cookie_samesite,
-            )
+            # Key the cookie claim by the configured field name
+            # (``self.sso_cookie`` == ``SSO_COOKIE_DATA``) rather than a
+            # hardcoded ``"email"``. The old hardcoded key stored e.g. the
+            # username *value* under an ``"email"`` key, so ``authenticate_sso``
+            # could only ever look users up by email — ambiguous when accounts
+            # share one. Producer and consumer now agree on the same field,
+            # defaulting to ``email`` for unchanged deployments.
+            sso_value = getattr(user, self.sso_cookie, None)
+            # Skip the cookie entirely when the configured field is empty
+            # rather than issuing a dead ``{field: null}``/``{field: ""}``
+            # cookie that the consumer can never resolve to a user.
+            if sso_value:
+                sso_cookie = jwt.encode(
+                    {self.sso_cookie: sso_value},
+                    config.get("JWT_SECRET_KEY"),
+                    config.get("JWT_ALGORITHM"),
+                )
+                response.set_cookie(
+                    SSO_COOKIE_NAME,
+                    value=sso_cookie,
+                    max_age=self.cookie_max_age,
+                    domain=self.cookie_domain,
+                    path=self.cookie_path,
+                    httponly=self.cookie_httponly,
+                    secure=self._resolve_cookie_secure(),
+                    samesite=self.cookie_samesite,
+                )
 
         return response
 
@@ -461,11 +467,19 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         ``email`` is not unique on the user model, so an email lookup can
         return several accounts. ``username`` *is* unique, so the
         ``preferred_username`` claim is authoritative: when it matches one of
-        the email-matched accounts we attach to exactly that account. We bind
-        by email alone only when the match is unambiguous (a single account).
-        When several accounts share the email and none matches the username
-        claim we return ``None`` so the caller fails closed (auto-create or a
-        401) instead of binding the session to an arbitrary account.
+        the email-matched accounts we attach to exactly that account.
+
+        Resolution order, given the email match cardinality:
+
+        - **Several accounts** (the case this method exists for): the username
+          claim must pick one of them. If it matches none, return ``None`` so
+          the caller fails closed (auto-create or a 401) instead of binding
+          the session to an arbitrary account. The username guard only
+          engages here, at cardinality >= 2.
+        - **Exactly one account**: bind to it. A single email match is
+          unambiguous, so it wins even when the username claim differs or is
+          absent (this preserves the pre-change behaviour).
+        - **No accounts**: return ``None``.
 
         :param matched_users: queryset of accounts matched by email
         :param claimed_username: the unique username carried by the token, or

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -341,8 +341,14 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             login(request, user, backend=self.auth_backend)
 
         if self.use_sso:
+            # Key the cookie claim by the configured field name (``self.sso_cookie``
+            # == ``SSO_COOKIE_DATA``) rather than a hardcoded ``"email"``. The old
+            # hardcoded key stored e.g. the username *value* under an ``"email"``
+            # key, so ``authenticate_sso`` could only ever look users up by email —
+            # ambiguous when accounts share one. Producer and consumer now agree on
+            # the same field, defaulting to ``email`` for unchanged deployments.
             sso_cookie = jwt.encode(
-                {"email": getattr(user, self.sso_cookie, "email")},
+                {self.sso_cookie: getattr(user, self.sso_cookie, None)},
                 config.get("JWT_SECRET_KEY"),
                 config.get("JWT_ALGORITHM"),
             )
@@ -563,27 +569,34 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                     provided_username = form_data.get("username")
                     if provided_username:
                         user_data.update({"username": provided_username})
-                    filter_kwargs = None
                     q_objects = Q()
+                    matched_users = None
 
                     if "email" in user_data:
-                        filter_kwargs = {"email__iexact": user_data.get("email")}
+                        matched_users = self.user_model.objects.filter(
+                            email__iexact=user_data.get("email")
+                        )
                     elif "emails" in user_data and user_data["emails"]:
                         emails: List[str] = user_data["emails"]
                         for email in emails:
                             q_objects |= Q(email__iexact=email)
                         user_data["email"] = user_data["emails"][0]
+                        matched_users = self.user_model.objects.filter(q_objects)
 
-                    if (
-                        filter_kwargs
-                        and self.user_model.objects.filter(**filter_kwargs).exists()
-                    ):
-                        user = self.user_model.objects.get(**filter_kwargs)
-
-                    elif (
-                        q_objects and self.user_model.objects.filter(q_objects).exists()
-                    ):
-                        user = self.user_model.objects.get(q_objects)
+                    if matched_users is not None and matched_users.exists():
+                        # Email is not unique on the user model, so a lookup can
+                        # return several accounts. When it does, disambiguate with
+                        # the unique username carried by the ``preferred_username``
+                        # claim so we attach to the exact account that logged in
+                        # rather than letting ``.get()`` raise
+                        # ``MultipleObjectsReturned`` or picking one arbitrarily.
+                        claimed_username = user_data.get("username")
+                        if matched_users.count() > 1 and claimed_username:
+                            user = matched_users.filter(
+                                username=claimed_username
+                            ).first()
+                        if not user:
+                            user = matched_users.first()
 
                     if not user and not self.auto_create_user:
                         self._clear_login_states(server_response)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -212,3 +212,25 @@ class TestAuthenticateSSO(TestCase):
     def test_returns_none_without_sso_token(self):
         request = APIRequestFactory().get("/")
         self.assertIsNone(authenticate_sso(request))
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=SSO_AUTH_CONFIG)
+    def test_malformed_token_fails_closed(self):
+        """A malformed token returns None rather than raising."""
+        request = APIRequestFactory().get("/")
+        request.COOKIES["SSO"] = "not-a-jwt"
+        self.assertIsNone(authenticate_sso(request))
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=SSO_AUTH_CONFIG)
+    def test_token_signed_with_wrong_key_fails_closed(self):
+        """A token signed with the wrong secret returns None, not a 500."""
+        User.objects.create_user(
+            username="erin", email="erin@example.com", is_active=True
+        )
+        token = jwt.encode(
+            {"email": "erin@example.com"},
+            "a-different-secret-key-than-the-server-uses",
+            "HS256",
+        )
+        request = APIRequestFactory().get("/")
+        request.COOKIES["SSO"] = token
+        self.assertIsNone(authenticate_sso(request))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,37 @@
 """Tests for module oidc.utils"""
 
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings
 
+import jwt
 from rest_framework.test import APIRequestFactory
 
 from oidc.utils import (
+    authenticate_sso,
     get_login_query_param_allowlist,
     is_safe_login_redirect,
 )
+
+User = get_user_model()
+
+SSO_AUTH_CONFIG = {
+    "JWT_SECRET_KEY": "test-secret-key-that-is-long-enough-to-be-ok",
+    "JWT_ALGORITHM": "HS256",
+}
+
+
+def _make_sso_request(payload):
+    """Build a request carrying a signed SSO cookie for ``payload``."""
+    token = jwt.encode(
+        payload,
+        SSO_AUTH_CONFIG["JWT_SECRET_KEY"],
+        SSO_AUTH_CONFIG["JWT_ALGORITHM"],
+    )
+    request = APIRequestFactory().get("/")
+    request.COOKIES["SSO"] = token
+    return request
 
 
 class TestGetLoginQueryParamAllowlist(TestCase):
@@ -122,3 +144,71 @@ class TestIsSafeLoginRedirect(TestCase):
             is_safe_login_redirect(
                 "https://spa.example.com/x", "default", self._request()
             )
+
+
+class TestAuthenticateSSO(TestCase):
+    """Tests for ``authenticate_sso`` SSO cookie/header resolution."""
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=SSO_AUTH_CONFIG)
+    def test_email_default_resolves_user(self):
+        """With no SSO_COOKIE_DATA override, lookup falls back to email."""
+        user = User.objects.create_user(
+            username="alice", email="alice@example.com", is_active=True
+        )
+        request = _make_sso_request({"email": "alice@example.com"})
+        self.assertEqual(authenticate_sso(request), (user, True))
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={**SSO_AUTH_CONFIG, "SSO_COOKIE_DATA": "username"}
+    )
+    def test_resolves_correct_account_by_username_for_shared_email(self):
+        """
+        Two accounts sharing an email are disambiguated by the unique
+        username claim instead of an arbitrary ``.first()`` pick.
+        """
+        User.objects.create_user(
+            username="john", email="team@example.com", is_active=True
+        )
+        jane = User.objects.create_user(
+            username="jane", email="team@example.com", is_active=True
+        )
+        request = _make_sso_request({"username": "jane"})
+        self.assertEqual(authenticate_sso(request), (jane, True))
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={**SSO_AUTH_CONFIG, "SSO_COOKIE_DATA": "username"}
+    )
+    def test_returns_none_when_configured_claim_missing(self):
+        """A legacy cookie missing the configured claim must not match."""
+        User.objects.create_user(
+            username="bob", email="bob@example.com", is_active=True
+        )
+        request = _make_sso_request({"email": "bob@example.com"})
+        self.assertIsNone(authenticate_sso(request))
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={**SSO_AUTH_CONFIG, "SSO_COOKIE_DATA": "email"}
+    )
+    def test_explicit_field_argument_overrides_config(self):
+        user = User.objects.create_user(
+            username="carol", email="carol@example.com", is_active=True
+        )
+        request = _make_sso_request({"username": "carol"})
+        self.assertEqual(
+            authenticate_sso(request, unique_user_field="username"), (user, True)
+        )
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={**SSO_AUTH_CONFIG, "SSO_COOKIE_DATA": "username"}
+    )
+    def test_inactive_user_not_authenticated(self):
+        User.objects.create_user(
+            username="dave", email="dave@example.com", is_active=False
+        )
+        request = _make_sso_request({"username": "dave"})
+        self.assertIsNone(authenticate_sso(request))
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=SSO_AUTH_CONFIG)
+    def test_returns_none_without_sso_token(self):
+        request = APIRequestFactory().get("/")
+        self.assertIsNone(authenticate_sso(request))

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1427,6 +1427,78 @@ class TestUserModelOpenIDConnectViewset(TestCase):
             )
 
     @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "SSO_COOKIE_DATA": "username",
+        }
+    )
+    def test_disambiguates_shared_email_by_username(self):
+        """
+        When two accounts share an email, the callback attaches to the one
+        whose username matches the ``preferred_username`` claim instead of
+        raising MultipleObjectsReturned or picking an arbitrary account.
+        """
+        User.objects.create_user(
+            username="john", email="team@example.com", first_name="John"
+        )
+        jane = User.objects.create_user(
+            username="jane", email="team@example.com", first_name="Jane"
+        )
+
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_func:
+            mock_func.return_value = {
+                "given_name": "Jane",
+                "family_name": "Doe",
+                "email": "team@example.com",
+                "preferred_username": "jane",
+            }
+            data = {"id_token": "test.token.here"}
+            request = self.factory.post("/", data=data)
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 302)
+        # The matching account was logged in...
+        jane.refresh_from_db()
+        self.assertIsNotNone(jane.last_login)
+        # ...and the other account sharing the email was left untouched.
+        self.assertIsNone(User.objects.get(username="john").last_login)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "SSO_COOKIE_DATA": "username",
+        }
+    )
+    def test_sso_cookie_payload_uses_configured_field(self):
+        """The SSO cookie encodes the configured field as its claim key."""
+        User.objects.create_user(
+            username="patrick", email="patrick@example.com", first_name="Patrick"
+        )
+
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_func:
+            mock_func.return_value = {
+                "given_name": "Patrick",
+                "family_name": "Doe",
+                "email": "patrick@example.com",
+                "preferred_username": "patrick",
+            }
+            data = {"id_token": "test.token.here"}
+            request = self.factory.post("/", data=data)
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 302)
+        sso_cookie = response.cookies.get("SSO")
+        self.assertIsNotNone(sso_cookie)
+        payload = jwt.decode(sso_cookie.value, "abc", algorithms=["HS256"])
+        self.assertEqual(payload, {"username": "patrick"})
+
+    @override_settings(
         OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
         OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
     )

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1499,6 +1499,79 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(payload, {"username": "patrick"})
 
     @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "AUTO_CREATE_USER": False,
+        }
+    )
+    def test_shared_email_with_unmatched_username_is_not_authorized(self):
+        """
+        When several accounts share an email and the ``preferred_username``
+        claim matches none of them, the callback must fail closed instead of
+        binding the session to an arbitrary shared-email account.
+        """
+        User.objects.create_user(
+            username="john", email="team@example.com", first_name="John"
+        )
+        User.objects.create_user(
+            username="jane", email="team@example.com", first_name="Jane"
+        )
+
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_func:
+            mock_func.return_value = {
+                "given_name": "Ghost",
+                "family_name": "User",
+                "email": "team@example.com",
+                "preferred_username": "ghost",
+            }
+            data = {"id_token": "test.token.here"}
+            request = self.factory.post("/", data=data)
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 401)
+        # Neither account sharing the email was logged in.
+        self.assertIsNone(User.objects.get(username="john").last_login)
+        self.assertIsNone(User.objects.get(username="jane").last_login)
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_shared_email_unmatched_username_does_not_bind_with_auto_create(self):
+        """
+        With auto-create on (the default), a shared email whose
+        ``preferred_username`` matches no existing account must still not bind
+        the session to an arbitrary shared-email account.
+        """
+        User.objects.create_user(
+            username="john", email="team@example.com", first_name="John"
+        )
+        User.objects.create_user(
+            username="jane", email="team@example.com", first_name="Jane"
+        )
+
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_func:
+            mock_func.return_value = {
+                "given_name": "Ghost",
+                "family_name": "User",
+                "email": "team@example.com",
+                "preferred_username": "ghost",
+            }
+            data = {"id_token": "test.token.here"}
+            request = self.factory.post("/", data=data)
+            view(request, auth_server="default")
+
+        # Neither shared-email account was logged in, and the email already
+        # being in use routes to the username form rather than creating a
+        # duplicate "ghost" account.
+        self.assertIsNone(User.objects.get(username="john").last_login)
+        self.assertIsNone(User.objects.get(username="jane").last_login)
+        self.assertFalse(User.objects.filter(username="ghost").exists())
+
+    @override_settings(
         OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
         OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
     )
@@ -2127,3 +2200,61 @@ class TestPerProviderTargetUrlAfterAuth(TestCase):
         self.assertEqual(primary_response.url, "https://primary.example.com/landing")
         self.assertEqual(secondary_response.status_code, 302)
         self.assertEqual(secondary_response.url, "https://secondary.example.com")
+
+
+class TestResolveMatchedUser(TestCase):
+    """Tests for ``BaseOpenIDConnectViewset._resolve_matched_user``."""
+
+    def _shared_email_accounts(self):
+        john = User.objects.create_user(username="john", email="team@example.com")
+        jane = User.objects.create_user(username="jane", email="team@example.com")
+        return john, jane
+
+    def test_picks_account_matching_username_claim(self):
+        """The unique username claim disambiguates a shared email."""
+        _, jane = self._shared_email_accounts()
+        matched = User.objects.filter(email__iexact="team@example.com")
+        self.assertEqual(
+            UserModelOpenIDConnectViewset._resolve_matched_user(matched, "jane"),
+            jane,
+        )
+
+    def test_returns_none_for_shared_email_when_username_matches_none(self):
+        """Fail closed when no shared-email account matches the username."""
+        self._shared_email_accounts()
+        matched = User.objects.filter(email__iexact="team@example.com")
+        self.assertIsNone(
+            UserModelOpenIDConnectViewset._resolve_matched_user(matched, "ghost")
+        )
+
+    def test_single_match_binds_without_username(self):
+        """An unambiguous single match binds even without a username claim."""
+        solo = User.objects.create_user(username="solo", email="solo@example.com")
+        matched = User.objects.filter(email__iexact="solo@example.com")
+        self.assertEqual(
+            UserModelOpenIDConnectViewset._resolve_matched_user(matched, None),
+            solo,
+        )
+
+    def test_single_match_binds_even_when_username_differs(self):
+        """A single email match is authoritative even if the username differs."""
+        solo = User.objects.create_user(username="solo", email="solo@example.com")
+        matched = User.objects.filter(email__iexact="solo@example.com")
+        self.assertEqual(
+            UserModelOpenIDConnectViewset._resolve_matched_user(matched, "renamed"),
+            solo,
+        )
+
+    def test_returns_none_for_empty_match(self):
+        """No matches resolves to None."""
+        matched = User.objects.filter(email__iexact="nobody@example.com")
+        self.assertIsNone(
+            UserModelOpenIDConnectViewset._resolve_matched_user(matched, "anyone")
+        )
+
+    def test_resolves_with_a_single_query(self):
+        """Resolution materializes the queryset once instead of fanning out."""
+        self._shared_email_accounts()
+        matched = User.objects.filter(email__iexact="team@example.com")
+        with self.assertNumQueries(1):
+            UserModelOpenIDConnectViewset._resolve_matched_user(matched, "jane")

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1501,6 +1501,82 @@ class TestUserModelOpenIDConnectViewset(TestCase):
     @override_settings(
         OPENID_CONNECT_VIEWSET_CONFIG={
             **OPENID_CONNECT_VIEWSET_CONFIG,
+            "SSO_COOKIE_DATA": "last_name",
+        }
+    )
+    def test_no_sso_cookie_when_configured_field_is_empty(self):
+        """
+        No SSO cookie is emitted when the configured field has no value,
+        rather than issuing a dead ``{field: null}`` / ``{field: ""}`` cookie.
+        """
+        User.objects.create_user(
+            username="nolast",
+            email="nolast@example.com",
+            first_name="No",
+            last_name="",
+        )
+
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_func:
+            mock_func.return_value = {
+                "given_name": "No",
+                "family_name": "",
+                "email": "nolast@example.com",
+                "preferred_username": "nolast",
+            }
+            data = {"id_token": "test.token.here"}
+            request = self.factory.post("/", data=data)
+            response = view(request, auth_server="default")
+
+        # Login still succeeds...
+        self.assertEqual(response.status_code, 302)
+        # ...but no useless SSO cookie is set.
+        self.assertIsNone(response.cookies.get("SSO"))
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "SSO_COOKIE_DATA": "username",
+        }
+    )
+    def test_disambiguates_shared_email_by_username_via_emails_claim(self):
+        """
+        The plural ``emails`` claim path disambiguates a shared email by the
+        unique ``preferred_username`` exactly like the singular ``email`` path.
+        """
+        User.objects.create_user(
+            username="john", email="team@example.com", first_name="John"
+        )
+        jane = User.objects.create_user(
+            username="jane", email="team@example.com", first_name="Jane"
+        )
+
+        view = UserModelOpenIDConnectViewset.as_view({"post": "callback"})
+        with patch(
+            "oidc.viewsets.OpenIDClient.verify_and_decode_id_token"
+        ) as mock_func:
+            mock_func.return_value = {
+                "given_name": "Jane",
+                "family_name": "Doe",
+                "emails": ["NONEXISTENT@EXAMPLE.COM", "TEAM@EXAMPLE.COM"],
+                "preferred_username": "jane",
+            }
+            data = {"id_token": "test.token.here"}
+            request = self.factory.post("/", data=data)
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 302)
+        # The matching account was logged in...
+        jane.refresh_from_db()
+        self.assertIsNotNone(jane.last_login)
+        # ...and the other account sharing the email was left untouched.
+        self.assertIsNone(User.objects.get(username="john").last_login)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
             "AUTO_CREATE_USER": False,
         }
     )


### PR DESCRIPTION
## Problem

When two user accounts share an email (email is **not** unique on the user
model), Keycloak logins could map to the wrong OnaData account. `username` is
unique, so keying SSO resolution on it is unambiguous.

## Changes

- **`authenticate_sso` (`oidc/utils.py`)** — resolves the lookup field from
  `SSO_COOKIE_DATA` instead of a hardcoded `"email"` default, so the SSO cookie
  *producer* and *consumer* can never drift. Defaults to `email` for unchanged
  deployments. Also returns `None` when the configured claim is missing rather
  than falling through to `filter(field=None)` (which would match NULL columns).
- **SSO cookie creation (`oidc/viewsets.py`)** — keys the JWT claim by the
  configured field (`{self.sso_cookie: ...}`) instead of a hardcoded `"email"`
  key, which previously stored e.g. the username *value* under an `"email"` key.
- **Login callback matcher (`oidc/viewsets.py`)** — replaced
  `.get(email__iexact=…)` (which raised `MultipleObjectsReturned` on shared
  emails) with a queryset that disambiguates by the unique username from the
  `preferred_username` claim.

## Backward compatibility

Default deployments (no `SSO_COOKIE_DATA` override, i.e. `email`) behave exactly
as before — the cookie stays `{"email": user.email}` and lookup stays by email.

Deployments opting into `SSO_COOKIE_DATA="username"` should note that SSO
cookies issued before the change carry `{"email": …}` and will be treated as
unauthenticated after the switch, forcing a one-time re-authentication.

## Test plan

- [x] `python manage.py test tests` — 125 passing (8 new)
- [x] New tests: `authenticate_sso` field resolution (username/email/legacy
      claim/inactive/override), login disambiguation for shared emails, and the
      SSO cookie payload key.
- [x] black / isort / flake8 clean on changed files.
