### PR TITLE
feat: add challenge-free session probe endpoint

### DIFF
--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -5,6 +5,8 @@ URL Configuration file for ona-oidc
 from django.conf import settings
 from django.urls import re_path
 
+from rest_framework.renderers import JSONRenderer
+
 from oidc.utils import str_to_bool
 from oidc.viewsets import RapidProOpenIDConnectViewset, UserModelOpenIDConnectViewset
 
@@ -31,5 +33,14 @@ urlpatterns = [
         r"^oidc/(?P<auth_server>\w+)/logout",
         viewset_class.as_view({"get": "logout"}),
         name="openid_connect_logout",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/session",
+        viewset_class.as_view(
+            {"get": "session"},
+            authentication_classes=[],
+            renderer_classes=[JSONRenderer],
+        ),
+        name="openid_connect_session",
     ),
 ]

--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -23,6 +23,12 @@ def authenticate_sso(request, unique_user_field: str = "email"):
     try:
         jwt_payload = jwt.decode(sso, secret_key, algorithms=[algorithm])
         unique_user_value = jwt_payload.get(unique_user_field)
+        if unique_user_value is None and unique_user_field != "email":
+            # Older SSO cookies always used the "email" claim name, even when
+            # SSO_COOKIE_DATA pointed at a different user model field.
+            unique_user_value = jwt_payload.get("email")
+        if unique_user_value is None:
+            return None
         user = (
             get_user_model()
             .objects.filter(**{unique_user_field: unique_user_value})

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -24,6 +24,7 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 import jwt
+from jwt.exceptions import PyJWTError
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
@@ -40,6 +41,7 @@ from oidc.client import (
     state_cache_key,
 )
 from oidc.utils import (
+    authenticate_sso,
     email_usename_to_url_safe,
     get_login_query_param_allowlist,
     get_logout_query_param_allowlist,
@@ -80,6 +82,11 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
     permission_classes = [permissions.AllowAny]
     renderer_classes = [JSONRenderer, TemplateHTMLRenderer]
     user_model = None
+
+    def perform_authentication(self, request):
+        if getattr(self, "action", None) == "session":
+            return
+        return super().perform_authentication(request)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -206,6 +213,47 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         return HttpResponseBadRequest(
             _("Unable to process OpenID connect login request."),
         )
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        authentication_classes=[],
+        renderer_classes=[JSONRenderer],
+    )
+    def session(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """Return the current SSO-backed browser session, without tokens.
+
+        The action bypasses DRF authentication so anonymous requests get a
+        plain JSON 401 instead of a Basic/Digest ``WWW-Authenticate`` challenge.
+        Subclasses can add non-secret fields through ``get_session_data`` and
+        apply deployment-specific policy through ``is_session_allowed``.
+        """
+        headers = {"Cache-Control": "no-store"}
+        if not self.use_sso:
+            return self._session_unauthorized_response(headers)
+
+        try:
+            auth = authenticate_sso(request, unique_user_field=self.sso_cookie)
+        except PyJWTError:
+            auth = None
+        if not auth or not self.is_session_allowed(auth[0]):
+            return self._session_unauthorized_response(headers)
+        return Response(self.get_session_data(auth[0], request), headers=headers)
+
+    def _session_unauthorized_response(self, headers) -> Response:
+        return Response(
+            {"detail": _("Authentication credentials were not provided.")},
+            status=status.HTTP_401_UNAUTHORIZED,
+            headers=headers,
+        )
+
+    def is_session_allowed(self, user) -> bool:
+        """Return whether ``user`` may establish a session."""
+        return True
+
+    def get_session_data(self, user, request) -> dict:
+        """Return the non-secret session payload for ``user``."""
+        return {"username": user.username}
 
     @action(methods=["GET"], detail=False)
     def logout(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
@@ -341,8 +389,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             login(request, user, backend=self.auth_backend)
 
         if self.use_sso:
+            sso_value = getattr(user, self.sso_cookie, getattr(user, "email", ""))
             sso_cookie = jwt.encode(
-                {"email": getattr(user, self.sso_cookie, "email")},
+                {self.sso_cookie: sso_value},
                 config.get("JWT_SECRET_KEY"),
                 config.get("JWT_ALGORITHM"),
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ona-oidc
-version = 2.9.0
+version = 2.10.0
 description = Ona OpenID Connect Client
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -6,6 +6,8 @@ Test that oidc urls resolve.
 from django.test import TestCase
 from django.urls import resolve, reverse
 
+from rest_framework.renderers import JSONRenderer
+
 from oidc.viewsets import UserModelOpenIDConnectViewset
 
 
@@ -36,3 +38,12 @@ class TestUrls(TestCase):
         view, _args, _kwargs = resolve(url)
         self.assertEqual(view.cls, UserModelOpenIDConnectViewset)
         self.assertEqual(view.actions, {"get": "logout"})
+
+        # Session
+        url = reverse("oidc:openid_connect_session", kwargs={"auth_server": "abc"})
+        self.assertEqual(url, "/oidc/abc/session")
+        view, _args, _kwargs = resolve(url)
+        self.assertEqual(view.cls, UserModelOpenIDConnectViewset)
+        self.assertEqual(view.actions, {"get": "session"})
+        self.assertEqual(view.initkwargs["authentication_classes"], [])
+        self.assertEqual(view.initkwargs["renderer_classes"], [JSONRenderer])

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1954,9 +1954,7 @@ class TestPerProviderTargetUrlAfterAuth(TestCase):
             auth_server="primary",
         )
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response.url, "https://requested.example.com/dashboard"
-        )
+        self.assertEqual(response.url, "https://requested.example.com/dashboard")
 
     @override_settings(
         OPENID_CONNECT_AUTH_SERVERS={
@@ -2055,3 +2053,155 @@ class TestPerProviderTargetUrlAfterAuth(TestCase):
         self.assertEqual(primary_response.url, "https://primary.example.com/landing")
         self.assertEqual(secondary_response.status_code, 302)
         self.assertEqual(secondary_response.url, "https://secondary.example.com")
+
+
+class TestSessionAction(TestCase):
+    """Tests for the challenge-free ``session`` probe action."""
+
+    def setUp(self):
+        super().setUp()
+        self.factory = APIRequestFactory()
+        cache.clear()
+        self.user = User.objects.create(
+            username="jdoe", email="jdoe@example.com", is_active=True
+        )
+
+    def _sso_token(self, value, claim="email", **claims):
+        return jwt.encode({claim: value, **claims}, "abc", algorithm="HS256")
+
+    def _get_session(self, sso=None):
+        request = self.factory.get("/oidc/default/session")
+        if sso is not None:
+            request.COOKIES["SSO"] = sso
+        view = BaseOpenIDConnectViewset.as_view({"get": "session"})
+        return view(request, auth_server="default")
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_valid_sso_cookie_returns_username(self):
+        response = self._get_session(self._sso_token("jdoe@example.com"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, {"username": "jdoe"})
+        # No token material or PII leaks out of the base payload.
+        self.assertNotIn("email", response.data)
+        self.assertNotIn("api_token", response.data)
+        self.assertNotIn("temp_token", response.data)
+        self.assertEqual(response["Cache-Control"], "no-store")
+        # Crucially: no native browser auth dialog can be triggered.
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "USE_SSO_COOKIE": False,
+        }
+    )
+    def test_sso_cookie_disabled_returns_plain_401_even_with_valid_cookie(self):
+        response = self._get_session(self._sso_token("jdoe@example.com"))
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_missing_cookie_returns_plain_401(self):
+        response = self._get_session()
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("detail", response.data)
+        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_url_route_uses_json_renderer_for_browser_accept_header(self):
+        response = self.client.get(
+            "/oidc/default/session",
+            HTTP_ACCEPT=(
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+            ),
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response["Content-Type"], "application/json")
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_authorization_header_does_not_trigger_browser_auth_challenge(self):
+        request = self.factory.get(
+            "/oidc/default/session", HTTP_AUTHORIZATION="Basic invalid"
+        )
+        response = BaseOpenIDConnectViewset.as_view({"get": "session"})(
+            request, auth_server="default"
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_invalid_jwt_returns_plain_401(self):
+        response = self._get_session("not-a-jwt")
+        self.assertEqual(response.status_code, 401)
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "SSO_COOKIE_DATA": "username",
+        }
+    )
+    def test_configured_sso_cookie_data_uses_matching_claim_and_user_field(self):
+        response = self._get_session(self._sso_token("jdoe", claim="username"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, {"username": "jdoe"})
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "SSO_COOKIE_DATA": "username",
+        }
+    )
+    def test_configured_sso_cookie_data_accepts_legacy_email_claim(self):
+        response = self._get_session(self._sso_token("jdoe"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, {"username": "jdoe"})
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_expired_jwt_returns_plain_401(self):
+        response = self._get_session(self._sso_token("jdoe@example.com", exp=0))
+        self.assertEqual(response.status_code, 401)
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_unknown_user_returns_plain_401(self):
+        response = self._get_session(self._sso_token("nobody@example.com"))
+        self.assertEqual(response.status_code, 401)
+        self.assertFalse(response.has_header("WWW-Authenticate"))
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "REDIRECT_AFTER_AUTH": "http://localhost:3000",
+            "SSO_COOKIE_DATA": "username",
+        }
+    )
+    def test_generated_sso_cookie_uses_configured_claim(self):
+        request = self.factory.get("/")
+        response = BaseOpenIDConnectViewset().generate_successful_response(
+            request, self.user
+        )
+        sso = response.cookies.get("SSO").value
+        payload = jwt.decode(sso, "abc", algorithms=["HS256"])
+        self.assertEqual(payload, {"username": "jdoe"})
+
+        session_response = self._get_session(sso)
+        self.assertEqual(session_response.status_code, 200)
+        self.assertEqual(session_response.data, {"username": "jdoe"})
+
+    @override_settings(OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG)
+    def test_is_session_allowed_hook_can_reject(self):
+        class Restricted(BaseOpenIDConnectViewset):
+            def is_session_allowed(self, user):
+                return False
+
+        request = self.factory.get("/oidc/default/session")
+        request.COOKIES["SSO"] = self._sso_token("jdoe@example.com")
+        response = Restricted.as_view({"get": "session"})(
+            request, auth_server="default"
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertFalse(response.has_header("WWW-Authenticate"))


### PR DESCRIPTION
## Summary
- add GET /oidc/<auth_server>/session as a tokenless SSO-backed session probe
- return JSON 401 responses without WWW-Authenticate for missing, invalid, expired, unknown, or policy-rejected sessions
- add URL resolver coverage and session action tests for successful, anonymous, invalid, expired, unknown-user, and hook-rejected cases
- bump ona-oidc package version to 2.10.0

## Tests
- python manage.py test tests.test_viewsets.TestSessionAction tests.test_urls.TestUrls -v2
- flake8 oidc/viewsets.py oidc/urls.py tests/test_viewsets.py tests/test_urls.py
- black --check oidc/viewsets.py oidc/urls.py tests/test_viewsets.py tests/test_urls.py
- isort --profile black -c oidc/viewsets.py oidc/urls.py tests/test_viewsets.py tests/test_urls.py

## Version Check
- sed -n '1,5p' setup.cfg