### PR TITLE
refactor(oidc): generate URLs from a router

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,23 @@ default.
 These routes take identity from the OIDC tokens in `request.session`
 rather than `request.user`, and so run with DRF authentication
 disabled. State-changing methods are instead gated by
-`IsCsrfSafeAccountRequest`, which requires the
-`X-Ona-Account-Request` header and an `Origin` in the same trusted-host
-set as `LOGIN_REDIRECT_ALLOWED_HOSTS`. Neither check depends on the
-session cookie's `SameSite` attribute or on the deployment's CORS
-configuration.
+`IsCsrfSafeAccountRequest`, which requires a custom header and an
+`Origin` in the same trusted-host set as `LOGIN_REDIRECT_ALLOWED_HOSTS`.
+Neither check depends on the session cookie's `SameSite` attribute or on
+the deployment's CORS configuration.
+
+The header defaults to `X-Ona-Account-Request` and is configurable:
+
+```python
+OPENID_CONNECT_VIEWSET_CONFIG = {
+    ...,
+    "ACCOUNT_REQUEST_HEADER": "X-Acme-Account-Request",
+}
+```
+
+Any name works as a CSRF defence — what matters is that cross-site
+markup cannot set a custom header at all, not which name is used. The
+SPA must send whichever name is configured.
 
 #### Deployment requirements for the origin checks
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,31 @@ check inherit their strength from Django's `ALLOWED_HOSTS`:
   `Host`, and unlike `Host` a page can set it on a `fetch`. A proxy that
   forwards it lets a caller nominate its own origin as trusted.
 
+### Routing to your own viewset (`VIEWSET_CLASS`)
+
+Deployments that subclass the viewset — to reject certain account types,
+adjust cookie handling, and so on — can keep using `include("oidc.urls")`
+by naming the subclass:
+
+```python
+OPENID_CONNECT_VIEWSET_CONFIG = {
+    ...,
+    "VIEWSET_CLASS": "myapp.oidc_viewsets.MyOpenIDConnectViewset",
+}
+```
+
+Every route then goes to that class, including the account-proxy routes
+and their CSRF configuration. Without this the only way to change the
+viewset is to copy `oidc/urls.py` into your project, which means
+mirroring every future route and every `as_view()` kwarg by hand.
+
+An unimportable path raises rather than falling back to the built-in
+viewset — a silent fallback would drop whatever access rules the
+subclass enforces.
+
+`USE_RAPIDPRO_VIEWSET` is the older boolean form and still works;
+`VIEWSET_CLASS` takes precedence when both are set.
+
 4. (Optional) If you'd like to use the default OpenID Connect Viewset register the urls located in `oidc.urls`.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -186,6 +186,54 @@ restores the value from cache and uses it as the post-auth redirect.
 With `USE_NONCES=False` the nonce is still emitted purely as the cache
 key — no IdP-side nonce verification is performed.
 
+### Keycloak Account REST proxy (`ACCOUNT_ENDPOINT`)
+
+The account-proxy actions (profile update, sessions, linked accounts,
+credentials) forward to Keycloak's Account REST API. Point
+`ACCOUNT_ENDPOINT` at that realm's account root:
+
+```python
+OPENID_CONNECT_AUTH_SERVERS = {
+    "keycloak": {
+        ...,
+        "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/example/account",
+    }
+}
+```
+
+The setting is optional; the proxy actions return `503` while it is
+unset. Calls are made with the signed-in user's own `access_token`, so
+they need the `manage-account` role — granted to every realm user by
+default.
+
+These routes take identity from the OIDC tokens in `request.session`
+rather than `request.user`, and so run with DRF authentication
+disabled. State-changing methods are instead gated by
+`RequireAccountRequestHeader`, which requires the
+`X-Ona-Account-Request` header and an `Origin` in the same trusted-host
+set as `LOGIN_REDIRECT_ALLOWED_HOSTS`. Neither check depends on the
+session cookie's `SameSite` attribute or on the deployment's CORS
+configuration.
+
+#### Deployment requirements for the origin checks
+
+The trusted-host set is `LOGIN_REDIRECT_ALLOWED_HOSTS` plus the request's
+own host, so both the `next` validation and the account-proxy `Origin`
+check inherit their strength from Django's `ALLOWED_HOSTS`:
+
+* **Scope `ALLOWED_HOSTS` to the hosts you serve.** The request host is
+  read via `request.get_host()`, which Django rejects with a `400`
+  unless it matches `ALLOWED_HOSTS`. That validation is what keeps an
+  attacker-supplied `Host` out of the trusted set. With
+  `ALLOWED_HOSTS = ["*"]` there is no validation left, the header is
+  echoed back verbatim, and both checks degrade to comparing one
+  request header against another.
+
+* **With `USE_X_FORWARDED_HOST = True`, the proxy must strip any
+  client-supplied `X-Forwarded-Host`.** Django prefers that header over
+  `Host`, and unlike `Host` a page can set it on a `fetch`. A proxy that
+  forwards it lets a caller nominate its own origin as trusted.
+
 4. (Optional) If you'd like to use the default OpenID Connect Viewset register the urls located in `oidc.urls`.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ default.
 These routes take identity from the OIDC tokens in `request.session`
 rather than `request.user`, and so run with DRF authentication
 disabled. State-changing methods are instead gated by
-`RequireAccountRequestHeader`, which requires the
+`IsCsrfSafeAccountRequest`, which requires the
 `X-Ona-Account-Request` header and an `Origin` in the same trusted-host
 set as `LOGIN_REDIRECT_ALLOWED_HOSTS`. Neither check depends on the
 session cookie's `SameSite` attribute or on the deployment's CORS

--- a/oidc/client.py
+++ b/oidc/client.py
@@ -126,6 +126,7 @@ class OpenIDClient:
         self.scope = config[auth_server].get("SCOPE") or default_config["SCOPE"]
         self.token_endpoint = config[auth_server].get("TOKEN_ENDPOINT")
         self.end_session_endpoint = config[auth_server].get("END_SESSION_ENDPOINT")
+        self.account_endpoint = config[auth_server].get("ACCOUNT_ENDPOINT")
         self.redirect_uri = config[auth_server].get("REDIRECT_URI")
         self.response_type = config[auth_server].get(
             "RESPONSE_TYPE", default_config["RESPONSE_TYPE"]
@@ -466,3 +467,77 @@ class OpenIDClient:
         separator = "&" if "?" in url else "?"
         query = urlencode(filtered, quote_via=quote, safe=_AUTHORIZE_URL_SAFE_CHARS)
         return HttpResponseRedirect(f"{url}{separator}{query}")
+
+    def refresh_access_token(self, refresh_token: str) -> dict:
+        """
+        Exchange a refresh_token for a fresh token pair at the
+        configured ``TOKEN_ENDPOINT``. Returns the parsed token
+        response (``access_token``, ``refresh_token``, ``expires_in``,
+        usually a new ``id_token`` too).
+
+        :raises TokenVerificationFailed: on any non-2xx from the IdP.
+        """
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        try:
+            response = requests.post(
+                self.token_endpoint,
+                data=data,
+                headers=headers,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            logger.exception(exc)
+            raise TokenVerificationFailed(
+                f"Failed to refresh access token: {exc}"
+            ) from exc
+        return response.json()
+
+    def request_keycloak_account(
+        self,
+        access_token: str,
+        method: str,
+        path_suffix: str,
+        json_body: Optional[Mapping[str, Any]] = None,
+    ) -> tuple[int, Optional[dict]]:
+        """
+        Issue a generic ``method`` request to ``account_endpoint + path_suffix``
+        on behalf of ``access_token``. Returns ``(status_code, body|None)``.
+
+        This is the single entry point for every Account REST proxy call
+        (profile update, sessions, linked-accounts, credentials). Pass
+        ``path_suffix=""`` and ``json_body=<fields>`` for a POST /account
+        profile update.
+        """
+        if not self.account_endpoint:
+            raise ValueError(
+                f"ACCOUNT_ENDPOINT is not configured for auth_server "
+                f"{self.auth_server!r}."
+            )
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+        }
+        kwargs: dict = {"headers": headers}
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+            kwargs["json"] = dict(json_body)
+        url = f"{self.account_endpoint}{path_suffix}"
+        try:
+            response = requests.request(method, url, **kwargs)
+        except requests.RequestException as exc:
+            logger.exception(exc)
+            raise
+
+        body: Optional[dict] = None
+        if response.content:
+            try:
+                body = response.json()
+            except ValueError:
+                body = None
+        return response.status_code, body

--- a/oidc/client.py
+++ b/oidc/client.py
@@ -475,7 +475,9 @@ class OpenIDClient:
         response (``access_token``, ``refresh_token``, ``expires_in``,
         usually a new ``id_token`` too).
 
-        :raises TokenVerificationFailed: on any non-2xx from the IdP.
+        :raises TokenVerificationFailed: the IdP answered and refused.
+        :raises requests.RequestException: the IdP could not be reached, or
+            ``TOKEN_ENDPOINT`` is unset/malformed.
         """
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         data = {
@@ -491,11 +493,18 @@ class OpenIDClient:
                 headers=headers,
             )
             response.raise_for_status()
-        except requests.RequestException as exc:
+        except requests.HTTPError as exc:
+            # The IdP answered and refused: the refresh token is spent,
+            # revoked, or issued to another client. That is a genuinely
+            # dead session, so the caller turns this into a 401.
             logger.exception(exc)
             raise TokenVerificationFailed(
                 f"Failed to refresh access token: {exc}"
             ) from exc
+        # Transport failures (DNS, timeout, unset TOKEN_ENDPOINT) are left to
+        # propagate. Reporting an unreachable IdP as "session expired" would
+        # send the user through a re-login that cannot fix it; the proxy maps
+        # RequestException to 502 instead.
         return response.json()
 
     def request_keycloak_account(

--- a/oidc/permissions.py
+++ b/oidc/permissions.py
@@ -19,21 +19,39 @@ when a cross-site SPA forces ``SameSite=None`` to send credentials.
 
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
-from oidc.utils import is_allowed_account_origin
+import oidc.settings as default
+from oidc.utils import get_viewset_config, is_allowed_account_origin
 
-#: Header the SPA sets on every state-changing account-proxy request.
-ACCOUNT_REQUEST_HEADER = "X-Ona-Account-Request"
+_default_config = getattr(default, "OPENID_CONNECT_VIEWSET_CONFIG", {})
+
+
+def get_account_request_header() -> str:
+    """The header the SPA must send on state-changing account-proxy requests.
+
+    Configurable via ``OPENID_CONNECT_VIEWSET_CONFIG["ACCOUNT_REQUEST_HEADER"]``
+    so deployments outside Ona are not stuck advertising an ``X-Ona-`` header.
+    Any value works as a CSRF defence: what matters is that cross-site markup
+    cannot set a custom header at all, not which name is used.
+    """
+    return get_viewset_config().get(
+        "ACCOUNT_REQUEST_HEADER", _default_config["ACCOUNT_REQUEST_HEADER"]
+    )
 
 
 class IsCsrfSafeAccountRequest(BasePermission):
-    message = (
-        f"State-changing account requests must include the "
-        f"{ACCOUNT_REQUEST_HEADER} header and come from a trusted origin."
-    )
+    @property
+    def message(self):
+        # Resolved per request, not at import: a class-level f-string would
+        # freeze the default and keep naming X-Ona-Account-Request after a
+        # deployment configured something else.
+        return (
+            f"State-changing account requests must include the "
+            f"{get_account_request_header()} header and come from a trusted origin."
+        )
 
     def has_permission(self, request, view):
         if request.method in SAFE_METHODS:
             return True
-        if not request.headers.get(ACCOUNT_REQUEST_HEADER):
+        if not request.headers.get(get_account_request_header()):
             return False
         return is_allowed_account_origin(view.kwargs.get("auth_server"), request)

--- a/oidc/permissions.py
+++ b/oidc/permissions.py
@@ -1,0 +1,47 @@
+"""
+CSRF protection for the cookie-identified Keycloak Account REST proxy.
+
+The proxy actions take the caller's identity from the OIDC tokens stashed in
+``request.session`` (a cookie), and run with ``authentication_classes=[]`` —
+so DRF's ``SessionAuthentication`` CSRF check does not apply. To keep the
+state-changing actions from being driven cross-site with the victim's ambient
+cookie, unsafe methods must carry a custom request header.
+
+Two in-code checks, so the boundary doesn't hinge on external CORS config:
+  * A custom header that cross-site markup (``<form>``, ``<img>``,
+    navigation) cannot set — so it can't forge these calls at all.
+  * An ``Origin`` allowlist (the trusted first-party SPA hosts) — so a
+    cross-origin page that *does* set the header via ``fetch`` is still
+    rejected server-side, regardless of how the deployment's CORS is set up.
+
+Neither depends on the session cookie's ``SameSite`` attribute (kept as
+``Lax`` + ``Secure`` as an additional layer), so the protection holds even
+when a cross-site SPA forces ``SameSite=None`` to send credentials.
+"""
+
+from rest_framework.permissions import BasePermission
+
+from oidc.utils import is_allowed_account_origin
+
+#: Header the SPA sets on every state-changing account-proxy request.
+ACCOUNT_REQUEST_HEADER = "X-Ona-Account-Request"
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+class RequireAccountRequestHeader(BasePermission):
+    message = (
+        f"State-changing account requests must include the "
+        f"{ACCOUNT_REQUEST_HEADER} header and come from a trusted origin."
+    )
+
+    def has_permission(self, request, view):
+        if request.method in _SAFE_METHODS:
+            return True
+        if not request.headers.get(ACCOUNT_REQUEST_HEADER):
+            return False
+        return is_allowed_account_origin(
+            request.headers.get("Origin"),
+            view.kwargs.get("auth_server"),
+            request,
+        )

--- a/oidc/permissions.py
+++ b/oidc/permissions.py
@@ -19,14 +19,12 @@ Neither depends on the session cookie's ``SameSite`` attribute (kept as
 when a cross-site SPA forces ``SameSite=None`` to send credentials.
 """
 
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 from oidc.utils import is_allowed_account_origin
 
 #: Header the SPA sets on every state-changing account-proxy request.
 ACCOUNT_REQUEST_HEADER = "X-Ona-Account-Request"
-
-_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
 class RequireAccountRequestHeader(BasePermission):
@@ -36,12 +34,8 @@ class RequireAccountRequestHeader(BasePermission):
     )
 
     def has_permission(self, request, view):
-        if request.method in _SAFE_METHODS:
+        if request.method in SAFE_METHODS:
             return True
         if not request.headers.get(ACCOUNT_REQUEST_HEADER):
             return False
-        return is_allowed_account_origin(
-            request.headers.get("Origin"),
-            view.kwargs.get("auth_server"),
-            request,
-        )
+        return is_allowed_account_origin(view.kwargs.get("auth_server"), request)

--- a/oidc/permissions.py
+++ b/oidc/permissions.py
@@ -3,11 +3,9 @@ CSRF protection for the cookie-identified Keycloak Account REST proxy.
 
 The proxy actions take the caller's identity from the OIDC tokens stashed in
 ``request.session`` (a cookie), and run with ``authentication_classes=[]`` —
-so DRF's ``SessionAuthentication`` CSRF check does not apply. To keep the
-state-changing actions from being driven cross-site with the victim's ambient
-cookie, unsafe methods must carry a custom request header.
-
-Two in-code checks, so the boundary doesn't hinge on external CORS config:
+so DRF's ``SessionAuthentication`` CSRF check does not apply. Unsafe methods
+are instead gated on two in-code checks, so the boundary doesn't hinge on
+external CORS config:
   * A custom header that cross-site markup (``<form>``, ``<img>``,
     navigation) cannot set — so it can't forge these calls at all.
   * An ``Origin`` allowlist (the trusted first-party SPA hosts) — so a
@@ -27,7 +25,7 @@ from oidc.utils import is_allowed_account_origin
 ACCOUNT_REQUEST_HEADER = "X-Ona-Account-Request"
 
 
-class RequireAccountRequestHeader(BasePermission):
+class IsCsrfSafeAccountRequest(BasePermission):
     message = (
         f"State-changing account requests must include the "
         f"{ACCOUNT_REQUEST_HEADER} header and come from a trusted origin."

--- a/oidc/routers.py
+++ b/oidc/routers.py
@@ -1,0 +1,20 @@
+"""
+Routers used to build this package's URLs.
+"""
+
+from rest_framework.routers import SimpleRouter
+
+
+class UnprefixedNameRouter(SimpleRouter):
+    """A router that names routes ``{url_name}``, not ``{basename}-{url_name}``.
+
+    ``reverse("oidc:openid_connect_login")`` is part of this package's public
+    surface — used by the unrecoverable-error template and by consumers — so
+    the names the hand-written URLconf declared have to survive. A stock
+    router would rename that route to ``oidc-openid_connect_login``.
+    """
+
+    routes = [
+        route._replace(name=route.name.replace("{basename}-", ""))
+        for route in SimpleRouter.routes
+    ]

--- a/oidc/settings.py
+++ b/oidc/settings.py
@@ -3,6 +3,9 @@ Settings Module for the oidc App
 """
 
 OPENID_CONNECT_VIEWSET_CONFIG = {
+    # Dotted path to the viewset oidc.urls routes to. Unset means the
+    # built-in one; set it to route to a project-owned subclass.
+    "VIEWSET_CLASS": None,
     "ACCOUNT_REQUEST_HEADER": "X-Ona-Account-Request",
     "REQUIRED_USER_CREATION_FIELDS": ["email", "first_name", "username"],
     "USER_CREATION_FIELDS": ["email", "first_name", "last_name", "username"],

--- a/oidc/settings.py
+++ b/oidc/settings.py
@@ -3,6 +3,7 @@ Settings Module for the oidc App
 """
 
 OPENID_CONNECT_VIEWSET_CONFIG = {
+    "ACCOUNT_REQUEST_HEADER": "X-Ona-Account-Request",
     "REQUIRED_USER_CREATION_FIELDS": ["email", "first_name", "username"],
     "USER_CREATION_FIELDS": ["email", "first_name", "last_name", "username"],
     "USER_DEFAULTS": {},

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -4,6 +4,7 @@ URL Configuration file for ona-oidc
 
 from django.conf import settings
 from django.urls import re_path
+from django.utils.module_loading import import_string
 
 from rest_framework.renderers import JSONRenderer
 
@@ -13,11 +14,28 @@ from oidc.viewsets import RapidProOpenIDConnectViewset, UserModelOpenIDConnectVi
 
 app_name = "oidc"
 
-viewset_class = UserModelOpenIDConnectViewset
 
-config = getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", {})
-if str_to_bool(config.get("USE_RAPIDPRO_VIEWSET", False)):
-    viewset_class = RapidProOpenIDConnectViewset
+def get_viewset_class():
+    """The viewset these URLs route to.
+
+    ``VIEWSET_CLASS`` (a dotted path) lets a deployment route to its own
+    subclass while still using ``include("oidc.urls")``. Without it, changing
+    this one name means copying the whole URLconf, and then mirroring every
+    route and every ``as_view()`` kwarg -- including the account-proxy CSRF
+    gate below -- by hand, forever.
+
+    ``USE_RAPIDPRO_VIEWSET`` is the older boolean form and still works.
+    """
+    config = getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", {})
+    dotted_path = config.get("VIEWSET_CLASS")
+    if dotted_path:
+        return import_string(dotted_path)
+    if str_to_bool(config.get("USE_RAPIDPRO_VIEWSET", False)):
+        return RapidProOpenIDConnectViewset
+    return UserModelOpenIDConnectViewset
+
+
+viewset_class = get_viewset_class()
 
 # Every account-proxy route must use these. Dropping authentication_classes
 # without IsCsrfSafeAccountRequest leaves the route CSRF-open; see the

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -5,8 +5,7 @@ URL Configuration file for ona-oidc
 from django.conf import settings
 from django.utils.module_loading import import_string
 
-from rest_framework.routers import SimpleRouter
-
+from oidc.routers import UnprefixedNameRouter
 from oidc.utils import str_to_bool
 from oidc.viewsets import RapidProOpenIDConnectViewset, UserModelOpenIDConnectViewset
 
@@ -32,37 +31,16 @@ def get_viewset_class():
     return UserModelOpenIDConnectViewset
 
 
-viewset_class = get_viewset_class()
-
-
-# Routes are generated from the @action decorators on the viewset, so each
-# action carries its own url_path, url_name and view kwargs -- including the
-# account-proxy CSRF gate, which previously had to be repeated per route here
-# and mirrored by every consumer that declared its own URLconf.
+# Routes come from the @action decorators, so each action carries its own
+# url_path, url_name and view kwargs — including the account-proxy CSRF gate,
+# which previously had to be repeated per route here and re-mirrored by every
+# consumer that declared its own URLconf.
 #
-# trailing_slash=False keeps the existing paths (/oidc/<server>/login, not
-# /login/). The auth_server capture lives in the prefix; SimpleRouter
-# interpolates it into every generated pattern.
-class _NameKeepingRouter(SimpleRouter):
-    """SimpleRouter without the ``{basename}-`` prefix on route names.
-
-    These URLs were hand-declared with explicit ``name=`` values before, and
-    ``reverse("oidc:openid_connect_login")`` is part of this package's surface
-    — used by the unrecoverable-error template and by consumers. A stock
-    router would rename every route to ``oidc-openid_connect_login``.
-    """
-
-    routes = [
-        (
-            route._replace(name=route.name.replace("{basename}-", ""))
-            if hasattr(route, "name")
-            else route
-        )
-        for route in SimpleRouter.routes
-    ]
-
-
-router = _NameKeepingRouter(trailing_slash=False)
-router.register(r"oidc/(?P<auth_server>\w+)", viewset_class, basename="oidc")
+# trailing_slash=False keeps paths as /oidc/<server>/login rather than
+# /login/; the entry-point actions opt back into an optional trailing slash
+# individually. auth_server is captured by the prefix, which the router
+# interpolates into every generated pattern.
+router = UnprefixedNameRouter(trailing_slash=False)
+router.register(r"oidc/(?P<auth_server>\w+)", get_viewset_class(), basename="oidc")
 
 urlpatterns = router.urls

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -7,7 +7,7 @@ from django.urls import re_path
 
 from rest_framework.renderers import JSONRenderer
 
-from oidc.permissions import RequireAccountRequestHeader
+from oidc.permissions import IsCsrfSafeAccountRequest
 from oidc.utils import str_to_bool
 from oidc.viewsets import RapidProOpenIDConnectViewset, UserModelOpenIDConnectViewset
 
@@ -20,11 +20,11 @@ if str_to_bool(config.get("USE_RAPIDPRO_VIEWSET", False)):
     viewset_class = RapidProOpenIDConnectViewset
 
 # Every account-proxy route must use these. Dropping authentication_classes
-# without RequireAccountRequestHeader leaves the route CSRF-open; see the
+# without IsCsrfSafeAccountRequest leaves the route CSRF-open; see the
 # "Keycloak Account REST proxy" section of the README.
 _ACCOUNT_PROXY_VIEW_KWARGS = {
     "authentication_classes": [],
-    "permission_classes": [RequireAccountRequestHeader],
+    "permission_classes": [IsCsrfSafeAccountRequest],
     "renderer_classes": [JSONRenderer],
 }
 

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -7,6 +7,7 @@ from django.urls import re_path
 
 from rest_framework.renderers import JSONRenderer
 
+from oidc.permissions import RequireAccountRequestHeader
 from oidc.utils import str_to_bool
 from oidc.viewsets import RapidProOpenIDConnectViewset, UserModelOpenIDConnectViewset
 
@@ -17,6 +18,15 @@ viewset_class = UserModelOpenIDConnectViewset
 config = getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", {})
 if str_to_bool(config.get("USE_RAPIDPRO_VIEWSET", False)):
     viewset_class = RapidProOpenIDConnectViewset
+
+# Every account-proxy route must use these. Dropping authentication_classes
+# without RequireAccountRequestHeader leaves the route CSRF-open; see the
+# "Keycloak Account REST proxy" section of the README.
+_ACCOUNT_PROXY_VIEW_KWARGS = {
+    "authentication_classes": [],
+    "permission_classes": [RequireAccountRequestHeader],
+    "renderer_classes": [JSONRenderer],
+}
 
 urlpatterns = [
     re_path(
@@ -35,12 +45,56 @@ urlpatterns = [
         name="openid_connect_logout",
     ),
     re_path(
-        r"^oidc/(?P<auth_server>\w+)/session",
+        r"^oidc/(?P<auth_server>\w+)/session$",
         viewset_class.as_view(
             {"get": "session"},
             authentication_classes=[],
             renderer_classes=[JSONRenderer],
         ),
         name="openid_connect_session",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/account$",
+        viewset_class.as_view({"post": "account"}, **_ACCOUNT_PROXY_VIEW_KWARGS),
+        name="openid_connect_account",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/sessions$",
+        viewset_class.as_view(
+            {"get": "sessions_list", "delete": "sessions_revoke_others"},
+            **_ACCOUNT_PROXY_VIEW_KWARGS,
+        ),
+        name="openid_connect_sessions",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/sessions/(?P<session_id>[a-zA-Z0-9._-]+)$",
+        viewset_class.as_view(
+            {"delete": "sessions_revoke_one"}, **_ACCOUNT_PROXY_VIEW_KWARGS
+        ),
+        name="openid_connect_sessions_revoke_one",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/linked-accounts$",
+        viewset_class.as_view({"get": "linked_list"}, **_ACCOUNT_PROXY_VIEW_KWARGS),
+        name="openid_connect_linked_list",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/linked-accounts/(?P<provider>[^/]+)/link-url$",
+        viewset_class.as_view({"get": "linked_link_url"}, **_ACCOUNT_PROXY_VIEW_KWARGS),
+        name="openid_connect_linked_link_url",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/linked-accounts/(?P<provider>[^/]+)$",
+        viewset_class.as_view(
+            {"delete": "linked_unlink"}, **_ACCOUNT_PROXY_VIEW_KWARGS
+        ),
+        name="openid_connect_linked_unlink",
+    ),
+    re_path(
+        r"^oidc/(?P<auth_server>\w+)/credentials$",
+        viewset_class.as_view(
+            {"get": "credentials_list"}, **_ACCOUNT_PROXY_VIEW_KWARGS
+        ),
+        name="openid_connect_credentials",
     ),
 ]

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -34,6 +34,7 @@ def get_viewset_class():
 
 viewset_class = get_viewset_class()
 
+
 # Routes are generated from the @action decorators on the viewset, so each
 # action carries its own url_path, url_name and view kwargs -- including the
 # account-proxy CSRF gate, which previously had to be repeated per route here
@@ -42,7 +43,26 @@ viewset_class = get_viewset_class()
 # trailing_slash=False keeps the existing paths (/oidc/<server>/login, not
 # /login/). The auth_server capture lives in the prefix; SimpleRouter
 # interpolates it into every generated pattern.
-router = SimpleRouter(trailing_slash=False)
+class _NameKeepingRouter(SimpleRouter):
+    """SimpleRouter without the ``{basename}-`` prefix on route names.
+
+    These URLs were hand-declared with explicit ``name=`` values before, and
+    ``reverse("oidc:openid_connect_login")`` is part of this package's surface
+    — used by the unrecoverable-error template and by consumers. A stock
+    router would rename every route to ``oidc-openid_connect_login``.
+    """
+
+    routes = [
+        (
+            route._replace(name=route.name.replace("{basename}-", ""))
+            if hasattr(route, "name")
+            else route
+        )
+        for route in SimpleRouter.routes
+    ]
+
+
+router = _NameKeepingRouter(trailing_slash=False)
 router.register(r"oidc/(?P<auth_server>\w+)", viewset_class, basename="oidc")
 
 urlpatterns = router.urls

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -3,12 +3,10 @@ URL Configuration file for ona-oidc
 """
 
 from django.conf import settings
-from django.urls import re_path
 from django.utils.module_loading import import_string
 
-from rest_framework.renderers import JSONRenderer
+from rest_framework.routers import SimpleRouter
 
-from oidc.permissions import IsCsrfSafeAccountRequest
 from oidc.utils import str_to_bool
 from oidc.viewsets import RapidProOpenIDConnectViewset, UserModelOpenIDConnectViewset
 
@@ -21,8 +19,7 @@ def get_viewset_class():
     ``VIEWSET_CLASS`` (a dotted path) lets a deployment route to its own
     subclass while still using ``include("oidc.urls")``. Without it, changing
     this one name means copying the whole URLconf, and then mirroring every
-    route and every ``as_view()`` kwarg -- including the account-proxy CSRF
-    gate below -- by hand, forever.
+    route by hand, forever.
 
     ``USE_RAPIDPRO_VIEWSET`` is the older boolean form and still works.
     """
@@ -37,82 +34,15 @@ def get_viewset_class():
 
 viewset_class = get_viewset_class()
 
-# Every account-proxy route must use these. Dropping authentication_classes
-# without IsCsrfSafeAccountRequest leaves the route CSRF-open; see the
-# "Keycloak Account REST proxy" section of the README.
-_ACCOUNT_PROXY_VIEW_KWARGS = {
-    "authentication_classes": [],
-    "permission_classes": [IsCsrfSafeAccountRequest],
-    "renderer_classes": [JSONRenderer],
-}
+# Routes are generated from the @action decorators on the viewset, so each
+# action carries its own url_path, url_name and view kwargs -- including the
+# account-proxy CSRF gate, which previously had to be repeated per route here
+# and mirrored by every consumer that declared its own URLconf.
+#
+# trailing_slash=False keeps the existing paths (/oidc/<server>/login, not
+# /login/). The auth_server capture lives in the prefix; SimpleRouter
+# interpolates it into every generated pattern.
+router = SimpleRouter(trailing_slash=False)
+router.register(r"oidc/(?P<auth_server>\w+)", viewset_class, basename="oidc")
 
-urlpatterns = [
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/login",
-        viewset_class.as_view({"get": "login"}),
-        name="openid_connect_login",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/callback",
-        viewset_class.as_view({"get": "callback", "post": "callback"}),
-        name="openid_connect_callback",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/logout",
-        viewset_class.as_view({"get": "logout"}),
-        name="openid_connect_logout",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/session$",
-        viewset_class.as_view(
-            {"get": "session"},
-            authentication_classes=[],
-            renderer_classes=[JSONRenderer],
-        ),
-        name="openid_connect_session",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/account$",
-        viewset_class.as_view({"post": "account"}, **_ACCOUNT_PROXY_VIEW_KWARGS),
-        name="openid_connect_account",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/sessions$",
-        viewset_class.as_view(
-            {"get": "sessions_list", "delete": "sessions_revoke_others"},
-            **_ACCOUNT_PROXY_VIEW_KWARGS,
-        ),
-        name="openid_connect_sessions",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/sessions/(?P<session_id>[a-zA-Z0-9._-]+)$",
-        viewset_class.as_view(
-            {"delete": "sessions_revoke_one"}, **_ACCOUNT_PROXY_VIEW_KWARGS
-        ),
-        name="openid_connect_sessions_revoke_one",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/linked-accounts$",
-        viewset_class.as_view({"get": "linked_list"}, **_ACCOUNT_PROXY_VIEW_KWARGS),
-        name="openid_connect_linked_list",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/linked-accounts/(?P<provider>[^/]+)/link-url$",
-        viewset_class.as_view({"get": "linked_link_url"}, **_ACCOUNT_PROXY_VIEW_KWARGS),
-        name="openid_connect_linked_link_url",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/linked-accounts/(?P<provider>[^/]+)$",
-        viewset_class.as_view(
-            {"delete": "linked_unlink"}, **_ACCOUNT_PROXY_VIEW_KWARGS
-        ),
-        name="openid_connect_linked_unlink",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/credentials$",
-        viewset_class.as_view(
-            {"get": "credentials_list"}, **_ACCOUNT_PROXY_VIEW_KWARGS
-        ),
-        name="openid_connect_credentials",
-    ),
-]
+urlpatterns = router.urls

--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -161,13 +161,13 @@ def is_safe_login_redirect(
     )
 
 
-def is_allowed_account_origin(
-    origin: Optional[str], auth_server: str, request: HttpRequest
-) -> bool:
+def is_allowed_account_origin(auth_server: str, request: HttpRequest) -> bool:
     """
-    Whether ``origin`` (an ``Origin`` header value, ``scheme://host``) is a
-    trusted first-party SPA for account-proxy calls.
+    Whether ``request``'s ``Origin`` header is a trusted first-party SPA for
+    account-proxy calls. A missing ``Origin`` is allowed — same-origin
+    requests may omit it, and the custom-header requirement still gates those.
     """
+    origin = request.headers.get("Origin")
     if not origin:
         return True
 

--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -1,4 +1,5 @@
 from typing import Iterable, Optional
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -80,6 +81,17 @@ def _coerce_string_iterable(value, key: str, auth_server: str) -> Iterable[str]:
     return value
 
 
+def _server_setting_values(auth_server: str, key: str) -> Iterable[str]:
+    """Validated string values of ``key`` for ``auth_server``; empty when unset.
+
+    Keeps ``key`` named once per call site — it is otherwise repeated as both
+    the lookup and the error label, which drift apart under rename.
+    """
+    config = getattr(settings, "OPENID_CONNECT_AUTH_SERVERS", {})
+    server_config = config.get(auth_server, {})
+    return _coerce_string_iterable(server_config.get(key, ()), key, auth_server)
+
+
 def get_login_query_param_allowlist(auth_server: str) -> frozenset[str]:
     """
     Return the set of query parameter names that the login view is allowed to
@@ -90,15 +102,7 @@ def get_login_query_param_allowlist(auth_server: str) -> frozenset[str]:
     Defaults to an empty set so unknown query params are dropped at the
     viewset boundary.
     """
-    config = getattr(settings, "OPENID_CONNECT_AUTH_SERVERS", {})
-    server_config = config.get(auth_server, {})
-    return frozenset(
-        _coerce_string_iterable(
-            server_config.get("LOGIN_QUERY_PARAM_ALLOWLIST", ()),
-            "LOGIN_QUERY_PARAM_ALLOWLIST",
-            auth_server,
-        )
-    )
+    return frozenset(_server_setting_values(auth_server, "LOGIN_QUERY_PARAM_ALLOWLIST"))
 
 
 def get_logout_query_param_allowlist(auth_server: str) -> frozenset[str]:
@@ -111,15 +115,24 @@ def get_logout_query_param_allowlist(auth_server: str) -> frozenset[str]:
     Defaults to an empty set so unknown query params are dropped at the
     viewset boundary — matches the ``LOGIN_QUERY_PARAM_ALLOWLIST`` shape.
     """
-    config = getattr(settings, "OPENID_CONNECT_AUTH_SERVERS", {})
-    server_config = config.get(auth_server, {})
     return frozenset(
-        _coerce_string_iterable(
-            server_config.get("LOGOUT_QUERY_PARAM_ALLOWLIST", ()),
-            "LOGOUT_QUERY_PARAM_ALLOWLIST",
-            auth_server,
-        )
+        _server_setting_values(auth_server, "LOGOUT_QUERY_PARAM_ALLOWLIST")
     )
+
+
+def _trusted_spa_hosts(auth_server: str, request: HttpRequest) -> set:
+    """Hosts trusted as the first-party SPA for ``auth_server``.
+
+    The request's own host plus any listed in
+    ``OPENID_CONNECT_AUTH_SERVERS[<server>]["LOGIN_REDIRECT_ALLOWED_HOSTS"]``.
+    One definition of "our SPA", reused by the login-redirect and the
+    account-proxy origin checks so they can't drift.
+    """
+    allowed_hosts = set(
+        _server_setting_values(auth_server, "LOGIN_REDIRECT_ALLOWED_HOSTS")
+    )
+    allowed_hosts.add(request.get_host())
+    return allowed_hosts
 
 
 def is_safe_login_redirect(
@@ -141,18 +154,30 @@ def is_safe_login_redirect(
     """
     if not url:
         return False
-    config = getattr(settings, "OPENID_CONNECT_AUTH_SERVERS", {})
-    server_config = config.get(auth_server, {})
-    allowed_hosts = set(
-        _coerce_string_iterable(
-            server_config.get("LOGIN_REDIRECT_ALLOWED_HOSTS", ()),
-            "LOGIN_REDIRECT_ALLOWED_HOSTS",
-            auth_server,
-        )
-    )
-    allowed_hosts.add(request.get_host())
     return url_has_allowed_host_and_scheme(
         url,
-        allowed_hosts=allowed_hosts,
+        allowed_hosts=_trusted_spa_hosts(auth_server, request),
+        require_https=request.is_secure(),
+    )
+
+
+def is_allowed_account_origin(
+    origin: Optional[str], auth_server: str, request: HttpRequest
+) -> bool:
+    """
+    Whether ``origin`` (an ``Origin`` header value, ``scheme://host``) is a
+    trusted first-party SPA for account-proxy calls.
+    """
+    if not origin:
+        return True
+
+    # Require an explicit scheme + host.
+    parsed = urlparse(origin)
+    if not parsed.scheme or not parsed.netloc:
+        return False
+
+    return url_has_allowed_host_and_scheme(
+        origin,
+        allowed_hosts=_trusted_spa_hosts(auth_server, request),
         require_https=request.is_secure(),
     )

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -89,6 +89,25 @@ def _sid_from_id_token(id_token: str) -> Optional[str]:
     return unverified.get("sid")
 
 
+#: Single wording for "this request carries no usable OIDC session". The
+#: account proxy is driven by one SPA, so the same state must not surface
+#: three different strings depending on which endpoint was hit.
+NO_ACTIVE_SESSION = {"error": "No active OIDC session — please sign in again."}
+
+
+def _authenticated_session(request: HttpRequest):
+    """The request's session if it carries an OIDC access token, else ``None``.
+
+    Identity for the account proxy is the stashed token, not ``request.user``:
+    ona-oidc only calls Django's ``login()`` when ``USE_AUTH_BACKEND`` is on,
+    which is off by default, so there is no authenticated user to rely on.
+    """
+    session = getattr(request, "session", None)
+    if session is None or not session.get("oidc_access_token"):
+        return None
+    return session
+
+
 def _current_sid(request: HttpRequest) -> Optional[str]:
     """The caller's Keycloak session id, from the id_token stashed at callback.
 
@@ -352,7 +371,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         """
         access_token = session.get("oidc_access_token")
         if not access_token:
-            return status.HTTP_401_UNAUTHORIZED, {"error": "No active OIDC session."}
+            return status.HTTP_401_UNAUTHORIZED, NO_ACTIVE_SESSION
 
         status_code, body = client.request_keycloak_account(
             access_token, method, path_suffix, json_body
@@ -408,12 +427,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                 {"error": "Account endpoint not configured."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
-        session = getattr(request, "session", None)
+        session = _authenticated_session(request)
         if session is None:
-            return Response(
-                {"error": "No active session."},
-                status=status.HTTP_401_UNAUTHORIZED,
-            )
+            return Response(NO_ACTIVE_SESSION, status=status.HTTP_401_UNAUTHORIZED)
         try:
             status_code, body = self._keycloak_account_request(
                 client, session, method, path_suffix, json_body
@@ -642,18 +658,9 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 
-        session = getattr(request, "session", None)
+        session = _authenticated_session(request)
         if session is None:
-            return Response(
-                {"error": "No active session."},
-                status=status.HTTP_401_UNAUTHORIZED,
-            )
-        access_token = session.get("oidc_access_token")
-        if not access_token:
-            return Response(
-                {"error": "No active OIDC session — please sign in again."},
-                status=status.HTTP_401_UNAUTHORIZED,
-            )
+            return Response(NO_ACTIVE_SESSION, status=status.HTTP_401_UNAUTHORIZED)
 
         # ``request.data`` is a QueryDict for form bodies and a plain
         # dict for JSON; ``.items()`` works for both.

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -227,6 +227,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
     @action(
         methods=["GET"],
         detail=False,
+        url_path=r"login/?",
         url_name="openid_connect_login",
     )
     def login(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
@@ -313,6 +314,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
     @action(
         methods=["GET"],
         detail=False,
+        url_path=r"logout/?",
         url_name="openid_connect_logout",
     )
     def logout(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
@@ -523,6 +525,11 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             f"/sessions/{session_id}",
         )
 
+    # Shares ``sessions_list``'s route rather than declaring its own: two
+    # actions on the same path would generate two identical patterns, and
+    # Django would resolve the first — leaving DELETE with a silent 405.
+    # Note this also inherits sessions_list's view kwargs, so the CSRF gate
+    # on this endpoint is configured there, not here.
     @sessions_list.mapping.delete
     def sessions_revoke_others(
         self, request: HttpRequest, **kwargs: dict
@@ -962,6 +969,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
     @action(
         methods=["POST", "GET"],
         detail=False,
+        url_path=r"callback/?",
         url_name="openid_connect_callback",
     )
     def callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -41,6 +41,7 @@ from oidc.client import (
     TokenVerificationFailed,
     state_cache_key,
 )
+from oidc.permissions import IsCsrfSafeAccountRequest
 from oidc.utils import (
     authenticate_sso,
     email_usename_to_url_safe,
@@ -223,7 +224,11 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             return bool(self.cookie_secure)
         return bool(getattr(settings, "SESSION_COOKIE_SECURE", False))
 
-    @action(methods=["GET"], detail=False)
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_name="openid_connect_login",
+    )
     def login(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)
@@ -268,6 +273,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         detail=False,
         authentication_classes=[],
         renderer_classes=[JSONRenderer],
+        url_name="openid_connect_session",
     )
     def session(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         """Return the current SSO-backed browser session, without tokens.
@@ -304,7 +310,11 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         """Return the non-secret session payload for ``user``."""
         return {"username": user.username}
 
-    @action(methods=["GET"], detail=False)
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_name="openid_connect_logout",
+    )
     def logout(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)
@@ -453,7 +463,15 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             status=status_code,
         )
 
-    @action(methods=["GET"], detail=False, url_path="sessions")
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="sessions",
+        url_name="openid_connect_sessions",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
     def sessions_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         """
         List the user's active Keycloak sessions. Flattens
@@ -476,6 +494,10 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         methods=["DELETE"],
         detail=False,
         url_path=r"sessions/(?P<session_id>[a-zA-Z0-9._-]+)",
+        url_name="openid_connect_sessions_revoke_one",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
     )
     def sessions_revoke_one(
         self, request: HttpRequest, session_id: str = "", **kwargs: dict
@@ -501,7 +523,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             f"/sessions/{session_id}",
         )
 
-    @action(methods=["DELETE"], detail=False, url_path="sessions")
+    @sessions_list.mapping.delete
     def sessions_revoke_others(
         self, request: HttpRequest, **kwargs: dict
     ) -> HttpResponse:
@@ -513,7 +535,15 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             "/sessions?current=false",
         )
 
-    @action(methods=["GET"], detail=False, url_path="linked-accounts")
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="linked-accounts",
+        url_name="openid_connect_linked_list",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
     def linked_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         """List broker IdPs configured on the realm with their connected
         state for the current user."""
@@ -528,6 +558,10 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         methods=["DELETE"],
         detail=False,
         url_path=r"linked-accounts/(?P<provider>[^/]+)",
+        url_name="openid_connect_linked_unlink",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
     )
     def linked_unlink(
         self, request: HttpRequest, provider: str = "", **kwargs: dict
@@ -549,6 +583,10 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         methods=["GET"],
         detail=False,
         url_path=r"linked-accounts/(?P<provider>[^/]+)/link-url",
+        url_name="openid_connect_linked_link_url",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
     )
     def linked_link_url(
         self, request: HttpRequest, provider: str = "", **kwargs: dict
@@ -569,7 +607,15 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             f"/linked-accounts/{provider}",
         )
 
-    @action(methods=["GET"], detail=False, url_path="credentials")
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="credentials",
+        url_name="openid_connect_credentials",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
     def credentials_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         """List credential metadata (TOTP / password / recovery codes).
 
@@ -631,7 +677,14 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                 )
         return rows
 
-    @action(methods=["POST"], detail=False)
+    @action(
+        methods=["POST"],
+        detail=False,
+        url_name="openid_connect_account",
+        authentication_classes=[],
+        permission_classes=[IsCsrfSafeAccountRequest],
+        renderer_classes=[JSONRenderer],
+    )
     def account(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         """
         Proxy a profile update from the SPA to Keycloak's Account REST
@@ -906,7 +959,11 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         if state:
             cache.delete(state_cache_key(state))
 
-    @action(methods=["POST", "GET"], detail=False)
+    @action(
+        methods=["POST", "GET"],
+        detail=False,
+        url_name="openid_connect_callback",
+    )
     def callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -6,7 +6,7 @@ import importlib
 import logging
 import re
 import traceback
-from typing import List, Optional, Tuple
+from typing import Any, Callable, List, Mapping, Optional, Tuple
 
 from django.conf import settings
 from django.contrib.auth import get_user_model, login
@@ -71,6 +71,35 @@ DEFAULT_USERNAME_PATTERN = r"^[A-Za-z0-9_]*$"
 DEFAULT_USERNAME_HELP_TEXT = "Username should not contain . @ - symbols"
 
 logger = logging.getLogger(__name__)
+
+
+_PROVIDER_ALIAS_RE = re.compile(r"^[a-z0-9_-]+$")
+
+
+def _sid_from_id_token(id_token: str) -> Optional[str]:
+    """Decode the ``sid`` claim from an id_token *without* verifying the
+    signature. The token was already verified at callback time and
+    stashed in the user's session; we only need the session-id claim
+    to power the revoke-current guard."""
+    try:
+        unverified = jwt.decode(id_token, options={"verify_signature": False})
+    except jwt.exceptions.InvalidTokenError:
+        return None
+    return unverified.get("sid")
+
+
+def _current_sid(request: HttpRequest) -> Optional[str]:
+    """The caller's Keycloak session id, from the id_token stashed at callback.
+
+    ``None`` when there is no session, no id_token, or no ``sid`` claim.
+    """
+    session = getattr(request, "session", None)
+    if session is None:
+        return None
+    id_token = session.get("oidc_id_token")
+    if not id_token:
+        return None
+    return _sid_from_id_token(id_token)
 
 
 class BaseOpenIDConnectViewset(viewsets.ViewSet):
@@ -297,6 +326,365 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             return response
         return HttpResponseBadRequest(
             _("Unable to process OpenID connect logout request."),
+        )
+
+    # Notably absent: ``email`` (owned by the verified email-change
+    # flow in OnaData — must not be set out-of-band) and ``username``
+    # (would diverge from the identity ona-oidc looks up by).
+    _ACCOUNT_UPDATE_ALLOWED_FIELDS = frozenset({"firstName", "lastName"})
+
+    def _keycloak_account_request(
+        self,
+        client: OpenIDClient,
+        session,
+        method: str,
+        path_suffix: str,
+        json_body: Optional[Mapping[str, Any]] = None,
+    ) -> Tuple[int, Optional[dict]]:
+        """
+        Call Keycloak's Account REST API as the session's user,
+        refreshing the stashed token pair and retrying once on 401.
+
+        Returns ``(upstream_status, parsed_json_or_None)``; network
+        failures bubble up as ``RequestException`` for the caller to
+        map to 502.
+        """
+        access_token = session.get("oidc_access_token")
+        if not access_token:
+            return 401, {"error": "No active OIDC session."}
+
+        status_code, body = client.request_keycloak_account(
+            access_token, method, path_suffix, json_body
+        )
+        if status_code != 401:
+            return status_code, body
+
+        refresh_token = session.get("oidc_refresh_token")
+        if not refresh_token:
+            return 401, body
+
+        try:
+            tokens = client.refresh_access_token(refresh_token)
+        except TokenVerificationFailed:
+            return 401, {"error": "Session expired — please sign in again."}
+
+        new_access = tokens.get("access_token")
+        new_refresh = tokens.get("refresh_token")
+        if new_access:
+            session["oidc_access_token"] = new_access
+        if new_refresh:
+            session["oidc_refresh_token"] = new_refresh
+        if not new_access:
+            return 401, body
+        return client.request_keycloak_account(
+            new_access, method, path_suffix, json_body
+        )
+
+    def _proxy_or_error(
+        self,
+        request: HttpRequest,
+        auth_server,
+        method: str,
+        path_suffix: str,
+        json_body: Optional[Mapping[str, Any]] = None,
+        transform: Optional[Callable[[Any], Any]] = None,
+    ) -> HttpResponse:
+        """
+        Shared wrapper for the proxy actions. ``transform`` runs on the
+        parsed body so per-endpoint normalisation stays close to the
+        action that needs it.
+        """
+        client = self._get_client(auth_server=auth_server)
+        if client is None:
+            return HttpResponseBadRequest(
+                _("Unable to process OpenID connect account request.")
+            )
+        if not client.account_endpoint:
+            return Response(
+                {"error": "Account endpoint not configured."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        session = getattr(request, "session", None)
+        if session is None:
+            return Response(
+                {"error": "No active session."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        try:
+            status_code, body = self._keycloak_account_request(
+                client, session, method, path_suffix, json_body
+            )
+        except Exception as exc:
+            logger.exception(exc)
+            return Response(
+                {"error": "Could not reach the identity provider."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+        if 200 <= status_code < 300:
+            payload = transform(body) if transform else body
+            return Response(payload, status=status_code)
+        return Response(
+            {"error": "Identity provider rejected the request.", "upstream": body},
+            status=status_code,
+        )
+
+    @action(methods=["GET"], detail=False, url_path="sessions")
+    def sessions_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """
+        List the user's active Keycloak sessions. Flattens
+        Keycloak's per-device representation into one row per
+        session so the SPA renders a flat list.
+        """
+        # Pin ``current`` to the id_token's ``sid`` claim — Keycloak's
+        # device-level flag marks every same-machine session current
+        # (see _flatten_session_devices).
+        current_sid = _current_sid(request)
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            "/sessions/devices",
+            transform=lambda body: self._flatten_session_devices(body, current_sid),
+        )
+
+    @action(
+        methods=["DELETE"],
+        detail=False,
+        url_path=r"sessions/(?P<session_id>[a-zA-Z0-9._-]+)",
+    )
+    def sessions_revoke_one(
+        self, request: HttpRequest, session_id: str = "", **kwargs: dict
+    ) -> HttpResponse:
+        """Revoke one Keycloak session by id. Rejects the user's current
+        session (defence in depth — the SPA already blocks this at the
+        button level)."""
+        current_sid = _current_sid(request)
+        if current_sid and current_sid == session_id:
+            return Response(
+                {
+                    "error": (
+                        "Cannot revoke the current session via this "
+                        "endpoint; use sign-out instead."
+                    )
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "DELETE",
+            f"/sessions/{session_id}",
+        )
+
+    @action(methods=["DELETE"], detail=False, url_path="sessions")
+    def sessions_revoke_others(
+        self, request: HttpRequest, **kwargs: dict
+    ) -> HttpResponse:
+        """Revoke every Keycloak session except the current one."""
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "DELETE",
+            "/sessions?current=false",
+        )
+
+    @action(methods=["GET"], detail=False, url_path="linked-accounts")
+    def linked_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """List broker IdPs configured on the realm with their connected
+        state for the current user."""
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            "/linked-accounts",
+        )
+
+    @action(
+        methods=["DELETE"],
+        detail=False,
+        url_path=r"linked-accounts/(?P<provider>[^/]+)",
+    )
+    def linked_unlink(
+        self, request: HttpRequest, provider: str = "", **kwargs: dict
+    ) -> HttpResponse:
+        """Unlink a broker IdP from the current user."""
+        if not _PROVIDER_ALIAS_RE.match(provider):
+            return Response(
+                {"error": "Invalid provider alias."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "DELETE",
+            f"/linked-accounts/{provider}",
+        )
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"linked-accounts/(?P<provider>[^/]+)/link-url",
+    )
+    def linked_link_url(
+        self, request: HttpRequest, provider: str = "", **kwargs: dict
+    ) -> HttpResponse:
+        """Get Keycloak's linked-account representation for
+        ``provider``, forwarded verbatim. Its ``accountLinkUri`` is the
+        one-shot URL the SPA opens in a new tab to drive the
+        broker-link flow."""
+        if not _PROVIDER_ALIAS_RE.match(provider):
+            return Response(
+                {"error": "Invalid provider alias."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            f"/linked-accounts/{provider}",
+        )
+
+    @action(methods=["GET"], detail=False, url_path="credentials")
+    def credentials_list(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """List credential metadata (TOTP / password / recovery codes).
+
+        Keycloak's nested wire shape (instances under
+        ``userCredentialMetadatas`` → ``credential``) is forwarded
+        verbatim — reshaping for rendering happens client-side in the
+        SPA.
+        """
+        return self._proxy_or_error(
+            request,
+            kwargs.get("auth_server"),
+            "GET",
+            "/credentials",
+        )
+
+    @staticmethod
+    def _flatten_session_devices(
+        body: Optional[list], current_sid: Optional[str] = None
+    ) -> list:
+        """``[{os, device, current, sessions:[{id, browser, ...}, ...]}, ...]``
+        → ``[{id, browser, os, started, ...}, ...]``.
+
+        Field placement matters: Keycloak's ``DeviceRepresentation`` carries
+        ``os``/``osVersion``/``device`` at the device level, but ``browser``
+        lives on each nested ``SessionRepresentation`` (two browsers on one
+        machine group under the same device, each its own session). So read
+        ``browser`` from the session, not the device.
+
+        ``current_sid`` is the ``sid`` claim from the caller's stashed
+        id_token; when known, a session is current iff its id matches.
+        Keycloak groups sessions by device fingerprint (OS + browser +
+        IP) and flags the *device* current, so two browsers on one
+        machine both read as current from Keycloak's own flags — the
+        SPA rendered exactly that bug. Falls back to Keycloak's flags
+        only when the sid is unavailable."""
+        if not body:
+            return []
+        rows: list = []
+        for device in body:
+            os_name = device.get("os")
+            device_current = bool(device.get("current"))
+            for sess in device.get("sessions", []) or []:
+                sid = sess.get("id")
+                if current_sid:
+                    is_current = sid == current_sid
+                else:
+                    is_current = bool(sess.get("current", device_current))
+                rows.append(
+                    {
+                        "id": sid,
+                        "browser": sess.get("browser"),
+                        "os": os_name,
+                        "ipAddress": sess.get("ipAddress"),
+                        "started": sess.get("started"),
+                        "lastAccess": sess.get("lastAccess"),
+                        "current": is_current,
+                        "clients": sess.get("clients", []),
+                    }
+                )
+        return rows
+
+    @action(methods=["POST"], detail=False)
+    def account(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
+        """
+        Proxy a profile update from the SPA to Keycloak's Account REST
+        API.
+
+        Body: JSON object with any of ``firstName`` / ``lastName``.
+        Everything else — including ``email``, owned by the verified
+        OnaData email-change flow — is silently dropped.
+
+        Returns:
+        - 200 ``{"success": true}`` on Keycloak 2xx.
+        - 401 if no session-stashed access_token, or if refresh fails.
+        - Upstream Keycloak status + body for any other non-2xx.
+        """
+        auth_server = kwargs.get("auth_server")
+        client = self._get_client(auth_server=auth_server)
+        if client is None:
+            return HttpResponseBadRequest(
+                _("Unable to process OpenID connect account update.")
+            )
+        if not client.account_endpoint:
+            return Response(
+                {"error": "Account endpoint not configured."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        session = getattr(request, "session", None)
+        if session is None:
+            return Response(
+                {"error": "No active session."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        access_token = session.get("oidc_access_token")
+        if not access_token:
+            return Response(
+                {"error": "No active OIDC session — please sign in again."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        # ``request.data`` is a QueryDict for form bodies and a plain
+        # dict for JSON; ``.items()`` works for both.
+        raw = request.data if hasattr(request, "data") else {}
+        payload = {
+            key: value
+            for key, value in raw.items()
+            if key in self._ACCOUNT_UPDATE_ALLOWED_FIELDS
+        }
+        if not payload:
+            return Response(
+                {
+                    "error": (
+                        "No allowed fields supplied. Allowed: "
+                        + ", ".join(sorted(self._ACCOUNT_UPDATE_ALLOWED_FIELDS))
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            status_code, body = self._keycloak_account_request(
+                client, session, "POST", "", json_body=payload
+            )
+        except Exception as exc:
+            logger.exception(exc)
+            return Response(
+                {"error": "Could not reach the identity provider."},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        if 200 <= status_code < 300:
+            return Response({"success": True}, status=status.HTTP_200_OK)
+
+        return Response(
+            {
+                "error": "Identity provider rejected the update.",
+                "upstream": body,
+            },
+            status=status_code,
         )
 
     def _username_field_config(self) -> Tuple[str, str]:
@@ -598,6 +986,16 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
                     callback_session = getattr(request, "session", None)
                     if id_token and callback_session is not None:
                         callback_session["oidc_id_token"] = id_token
+                    # Stash the token pair for the account-proxy actions
+                    # (and their refresh-on-401); ``user_tokens`` is the
+                    # raw token-endpoint response dict.
+                    if callback_session is not None and isinstance(user_tokens, dict):
+                        access_token = user_tokens.get("access_token")
+                        refresh_token = user_tokens.get("refresh_token")
+                        if access_token:
+                            callback_session["oidc_access_token"] = access_token
+                        if refresh_token:
+                            callback_session["oidc_refresh_token"] = refresh_token
                     user_claims = client.tokens_to_user_info(
                         self.map_claims_to_model_field(decoded_id_token),
                         id_token,

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -24,6 +24,7 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 import jwt
+import requests
 from jwt.exceptions import PyJWTError
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
@@ -351,22 +352,25 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         """
         access_token = session.get("oidc_access_token")
         if not access_token:
-            return 401, {"error": "No active OIDC session."}
+            return status.HTTP_401_UNAUTHORIZED, {"error": "No active OIDC session."}
 
         status_code, body = client.request_keycloak_account(
             access_token, method, path_suffix, json_body
         )
-        if status_code != 401:
+        if status_code != status.HTTP_401_UNAUTHORIZED:
             return status_code, body
 
         refresh_token = session.get("oidc_refresh_token")
         if not refresh_token:
-            return 401, body
+            return status.HTTP_401_UNAUTHORIZED, body
 
         try:
             tokens = client.refresh_access_token(refresh_token)
         except TokenVerificationFailed:
-            return 401, {"error": "Session expired — please sign in again."}
+            return (
+                status.HTTP_401_UNAUTHORIZED,
+                {"error": "Session expired — please sign in again."},
+            )
 
         new_access = tokens.get("access_token")
         new_refresh = tokens.get("refresh_token")
@@ -375,7 +379,7 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         if new_refresh:
             session["oidc_refresh_token"] = new_refresh
         if not new_access:
-            return 401, body
+            return status.HTTP_401_UNAUTHORIZED, body
         return client.request_keycloak_account(
             new_access, method, path_suffix, json_body
         )
@@ -414,13 +418,18 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             status_code, body = self._keycloak_account_request(
                 client, session, method, path_suffix, json_body
             )
-        except Exception as exc:
+        except (requests.RequestException, ValueError) as exc:
+            # Only genuine upstream problems: a transport failure, or an
+            # unconfigured ACCOUNT_ENDPOINT. Catching bare Exception here
+            # would report a bug in our own transform/flatten code as
+            # "the IdP is unreachable" and send the investigation to
+            # Keycloak instead of to us.
             logger.exception(exc)
             return Response(
                 {"error": "Could not reach the identity provider."},
                 status=status.HTTP_502_BAD_GATEWAY,
             )
-        if 200 <= status_code < 300:
+        if status.is_success(status_code):
             payload = transform(body) if transform else body
             return Response(payload, status=status_code)
         return Response(
@@ -669,14 +678,19 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             status_code, body = self._keycloak_account_request(
                 client, session, "POST", "", json_body=payload
             )
-        except Exception as exc:
+        except (requests.RequestException, ValueError) as exc:
+            # Only genuine upstream problems: a transport failure, or an
+            # unconfigured ACCOUNT_ENDPOINT. Catching bare Exception here
+            # would report a bug in our own transform/flatten code as
+            # "the IdP is unreachable" and send the investigation to
+            # Keycloak instead of to us.
             logger.exception(exc)
             return Response(
                 {"error": "Could not reach the identity provider."},
                 status=status.HTTP_502_BAD_GATEWAY,
             )
 
-        if 200 <= status_code < 300:
+        if status.is_success(status_code):
             return Response({"success": True}, status=status.HTTP_200_OK)
 
         return Response(

--- a/tests/project_viewsets.py
+++ b/tests/project_viewsets.py
@@ -1,0 +1,16 @@
+"""
+Stand-in for a project-owned viewset subclass.
+
+Mirrors how a consumer actually does this — onadata's
+``OnaOpenIDConnectViewset`` subclasses the concrete viewset to refuse SSO
+login for organization accounts. Kept in its own module, importing only
+``oidc.viewsets``: ``oidc.urls`` resolves ``VIEWSET_CLASS`` at import time, so
+a subclass module that reached back into ``oidc.urls`` would deadlock on a
+circular import.
+"""
+
+from oidc.viewsets import UserModelOpenIDConnectViewset
+
+
+class InjectedViewset(UserModelOpenIDConnectViewset):
+    """Subclass used to prove routing goes to the configured class."""

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -19,7 +19,7 @@ from mock import MagicMock, patch
 from rest_framework.test import APIRequestFactory
 
 from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
-from oidc.permissions import ACCOUNT_REQUEST_HEADER, IsCsrfSafeAccountRequest
+from oidc.permissions import IsCsrfSafeAccountRequest, get_account_request_header
 from oidc.viewsets import (
     DEFAULT_USERNAME_HELP_TEXT,
     DEFAULT_USERNAME_PATTERN,
@@ -2951,8 +2951,40 @@ class AccountProxyCsrfTests(TestCase):
         self.perm = IsCsrfSafeAccountRequest()
         self.view = SimpleNamespace(kwargs={"auth_server": "default"})
         self.header_kwarg = {
-            "HTTP_" + ACCOUNT_REQUEST_HEADER.upper().replace("-", "_"): "1"
+            "HTTP_" + get_account_request_header().upper().replace("-", "_"): "1"
         }
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "ACCOUNT_REQUEST_HEADER": "X-Acme-Account-Request",
+        }
+    )
+    def test_configured_header_replaces_the_default(self):
+        """A deployment that renames the header is gated on its own name, and
+        the shipped default stops working — otherwise the setting would only
+        widen what is accepted rather than move it."""
+        configured = self.factory.post("/", HTTP_X_ACME_ACCOUNT_REQUEST="1")
+        self.assertTrue(self.perm.has_permission(configured, self.view))
+
+        shipped_default = self.factory.post("/", HTTP_X_ONA_ACCOUNT_REQUEST="1")
+        self.assertFalse(self.perm.has_permission(shipped_default, self.view))
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "ACCOUNT_REQUEST_HEADER": "X-Acme-Account-Request",
+        }
+    )
+    def test_denial_message_names_the_configured_header(self):
+        """Pin: the message is resolved per request. As a class-level f-string
+        it would freeze the default at import and tell operators to send a
+        header the deployment no longer accepts."""
+        self.assertIn("X-Acme-Account-Request", self.perm.message)
+        self.assertNotIn("X-Ona-Account-Request", self.perm.message)
+
+    def test_defaults_to_the_shipped_header_when_unconfigured(self):
+        self.assertEqual(get_account_request_header(), "X-Ona-Account-Request")
 
     def test_safe_method_exempt(self):
         """GET/HEAD/OPTIONS need neither header nor origin."""

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -14,6 +14,7 @@ from django.urls import resolve
 from django.utils import timezone
 
 import jwt
+import requests
 from mock import MagicMock, patch
 from rest_framework.test import APIRequestFactory
 
@@ -1185,6 +1186,74 @@ class TestUserModelOpenIDConnectViewset(TestCase):
 
         self.assertEqual(response.status_code, 400)
         mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_update_refresh_rejected_by_idp_returns_401(self):
+        """The IdP answered and refused the refresh token: the session really
+        is dead, so signing in again is the right instruction."""
+        view = BaseOpenIDConnectViewset.as_view({"post": "account"})
+        request = self.factory.post("/", data={"firstName": "New"}, format="json")
+        request.session = {
+            "oidc_access_token": "expired.access.token",
+            "oidc_refresh_token": "revoked.refresh.token",
+        }
+
+        first_call = MagicMock(status_code=401, content=b"{}")
+        first_call.json.return_value = {"error": "invalid_token"}
+        refresh_call = MagicMock(status_code=400)
+        refresh_call.raise_for_status.side_effect = requests.HTTPError("400")
+
+        with (
+            patch("oidc.client.requests.request", return_value=first_call),
+            patch("oidc.client.requests.post", return_value=refresh_call),
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 401)
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_update_refresh_transport_failure_returns_502(self):
+        """Pin: an unreachable IdP (or an unset TOKEN_ENDPOINT, which raises
+        MissingSchema) must not be reported as an expired session. Doing so
+        sends the user through a re-login that cannot fix a server problem."""
+        view = BaseOpenIDConnectViewset.as_view({"post": "account"})
+        request = self.factory.post("/", data={"firstName": "New"}, format="json")
+        request.session = {
+            "oidc_access_token": "expired.access.token",
+            "oidc_refresh_token": "stashed.refresh.token",
+        }
+
+        first_call = MagicMock(status_code=401, content=b"{}")
+        first_call.json.return_value = {"error": "invalid_token"}
+
+        with (
+            patch("oidc.client.requests.request", return_value=first_call),
+            patch(
+                "oidc.client.requests.post",
+                side_effect=requests.ConnectionError("idp unreachable"),
+            ),
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 502)
 
     @override_settings(
         OPENID_CONNECT_AUTH_SERVERS={

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -19,7 +19,7 @@ from mock import MagicMock, patch
 from rest_framework.test import APIRequestFactory
 
 from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
-from oidc.permissions import ACCOUNT_REQUEST_HEADER, RequireAccountRequestHeader
+from oidc.permissions import ACCOUNT_REQUEST_HEADER, IsCsrfSafeAccountRequest
 from oidc.viewsets import (
     DEFAULT_USERNAME_HELP_TEXT,
     DEFAULT_USERNAME_PATTERN,
@@ -2521,7 +2521,7 @@ class TestAccountRoutes(TestCase):
             with self.subTest(path=path):
                 initkwargs = resolve(path).func.initkwargs
                 self.assertIn(
-                    RequireAccountRequestHeader,
+                    IsCsrfSafeAccountRequest,
                     initkwargs.get("permission_classes", []),
                 )
                 self.assertEqual(initkwargs.get("authentication_classes"), [])
@@ -2948,7 +2948,7 @@ class AccountProxyCsrfTests(TestCase):
 
     def setUp(self):
         self.factory = APIRequestFactory()
-        self.perm = RequireAccountRequestHeader()
+        self.perm = IsCsrfSafeAccountRequest()
         self.view = SimpleNamespace(kwargs={"auth_server": "default"})
         self.header_kwarg = {
             "HTTP_" + ACCOUNT_REQUEST_HEADER.upper().replace("-", "_"): "1"
@@ -3021,7 +3021,7 @@ class AccountProxyCsrfTests(TestCase):
         view = BaseOpenIDConnectViewset.as_view(
             {"post": "account"},
             authentication_classes=[],
-            permission_classes=[RequireAccountRequestHeader],
+            permission_classes=[IsCsrfSafeAccountRequest],
         )
         request = self.factory.post(
             "/", data={"firstName": "X"}, format="json", **self.header_kwarg

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1265,6 +1265,32 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         },
         OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
     )
+    def test_proxy_does_not_disguise_our_own_bugs_as_upstream_failures(self):
+        """Pin: only transport/config errors become 502. A defect in our own
+        response handling must surface as a 500 with a traceback, not as
+        'could not reach the identity provider' pointing at Keycloak."""
+        view = BaseOpenIDConnectViewset.as_view({"get": "credentials_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "t"}
+
+        with patch.object(
+            BaseOpenIDConnectViewset,
+            "_keycloak_account_request",
+            side_effect=KeyError("bug in transform"),
+        ):
+            with self.assertRaises(KeyError):
+                view(request, auth_server="default")
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
     def test_account_update_refreshes_on_401_and_retries(self):
         """Keycloak 401 → refresh access_token via refresh_token → retry.
         Session writeback so the next request uses the fresh token."""

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -3,12 +3,14 @@ Tests for the OpenID Client
 """
 
 import json
+from types import SimpleNamespace
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.urls import resolve
 from django.utils import timezone
 
 import jwt
@@ -16,6 +18,7 @@ from mock import MagicMock, patch
 from rest_framework.test import APIRequestFactory
 
 from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
+from oidc.permissions import ACCOUNT_REQUEST_HEADER, RequireAccountRequestHeader
 from oidc.viewsets import (
     DEFAULT_USERNAME_HELP_TEXT,
     DEFAULT_USERNAME_PATTERN,
@@ -1088,6 +1091,587 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         # End-session URL untouched — bare endpoint, no stray `?`/`&`.
         self.assertEqual(response.url, "http://localhost:3000")
 
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_update_no_session_token_returns_401(self):
+        """No stashed access_token → 401, never reach Keycloak."""
+        view = BaseOpenIDConnectViewset.as_view({"post": "account"})
+
+        request = self.factory.post(
+            "/", data={"email": "new@example.com"}, format="json"
+        )
+        request.session = {}
+        with patch("oidc.client.requests.request") as mock_request:
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 401)
+        # Critical: we never reached out to Keycloak.
+        mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_update_filters_disallowed_fields(self):
+        """Caller can only update ``firstName`` / ``lastName``; anything else —
+        including ``email`` (owned by the verified OnaData flow) — is dropped
+        before the request leaves our process."""
+        view = BaseOpenIDConnectViewset.as_view({"post": "account"})
+
+        request = self.factory.post(
+            "/",
+            data={
+                "firstName": "New",
+                "lastName": "Name",
+                "email": "new@example.com",
+                "username": "evil",
+                "enabled": False,
+                "realmRoles": ["admin"],
+            },
+            format="json",
+        )
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.content = b""
+        with patch(
+            "oidc.client.requests.request", return_value=mock_response
+        ) as mock_request:
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        # Bearer auth uses the stashed token.
+        _args, kwargs = mock_request.call_args
+        self.assertEqual(
+            kwargs["headers"]["Authorization"], "Bearer stashed.access.token"
+        )
+        # Only ``firstName`` / ``lastName`` forwarded — email + the rest dropped.
+        self.assertEqual(kwargs["json"], {"firstName": "New", "lastName": "Name"})
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_update_no_allowed_fields_returns_400(self):
+        """Request body that's all-disallowed → 400, never reach Keycloak."""
+        view = BaseOpenIDConnectViewset.as_view({"post": "account"})
+
+        request = self.factory.post("/", data={"username": "evil"}, format="json")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        with patch("oidc.client.requests.request") as mock_request:
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 400)
+        mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_update_refreshes_on_401_and_retries(self):
+        """Keycloak 401 → refresh access_token via refresh_token → retry.
+        Session writeback so the next request uses the fresh token."""
+        view = BaseOpenIDConnectViewset.as_view({"post": "account"})
+
+        request = self.factory.post("/", data={"firstName": "New"}, format="json")
+        request.session = {
+            "oidc_access_token": "expired.access.token",
+            "oidc_refresh_token": "stashed.refresh.token",
+        }
+
+        first_call = MagicMock(status_code=401, content=b"{}")
+        first_call.json.return_value = {"error": "invalid_token"}
+        refresh_call = MagicMock(status_code=200)
+        refresh_call.json.return_value = {
+            "access_token": "fresh.access.token",
+            "refresh_token": "fresh.refresh.token",
+        }
+        refresh_call.raise_for_status = MagicMock()
+        second_call = MagicMock(status_code=204, content=b"")
+
+        with (
+            patch(
+                "oidc.client.requests.request",
+                side_effect=[first_call, second_call],
+            ) as mock_request,
+            patch("oidc.client.requests.post", return_value=refresh_call) as mock_post,
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        # Two account calls (POST 401 → POST 204) plus one token refresh
+        # POST against ``token_endpoint``.
+        self.assertEqual(mock_request.call_count, 2)
+        self.assertEqual(mock_post.call_count, 1)
+        # Retry used the fresh token.
+        _args, kwargs = mock_request.call_args_list[1]
+        self.assertEqual(
+            kwargs["headers"]["Authorization"], "Bearer fresh.access.token"
+        )
+        # Session was updated with the fresh tokens.
+        self.assertEqual(request.session["oidc_access_token"], "fresh.access.token")
+        self.assertEqual(request.session["oidc_refresh_token"], "fresh.refresh.token")
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS=OPENID_CONNECT_AUTH_SERVERS,
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_account_update_returns_503_when_endpoint_not_configured(self):
+        """Deployments that haven't wired ``ACCOUNT_ENDPOINT`` get a
+        clear 503 — never reach Keycloak with a half-baked URL."""
+        view = BaseOpenIDConnectViewset.as_view({"post": "account"})
+
+        request = self.factory.post(
+            "/", data={"email": "new@example.com"}, format="json"
+        )
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        with patch("oidc.client.requests.post") as mock_post:
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 503)
+        mock_post.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_keycloak_account_request_get_passes_through_status_and_body(self):
+        """Shared helper round-trips method/path/body and surfaces upstream
+        (status, body). Refresh + retry exists already; this locks the
+        plain happy-path so the helper extraction is observably safe."""
+        viewset = BaseOpenIDConnectViewset()
+        client = OpenIDClient("default")
+        session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200, content=b'{"hello":"world"}')
+        upstream.json.return_value = {"hello": "world"}
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            status, body = viewset._keycloak_account_request(
+                client, session, "GET", "/sessions/devices"
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(body, {"hello": "world"})
+        args, kwargs = mock_request.call_args
+        self.assertEqual(args[0], "GET")
+        self.assertEqual(
+            args[1],
+            "https://idp.example.com/realms/r/account/sessions/devices",
+        )
+        self.assertEqual(
+            kwargs["headers"]["Authorization"], "Bearer stashed.access.token"
+        )
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_list_flattens_devices_into_rows(self):
+        """Keycloak returns DeviceRepresentation[] with nested sessions[].
+        Proxy flattens to a per-session list so the SPA renders rows,
+        not nested device groups. NOTE: ``browser`` lives on each nested
+        session, while ``os`` is on the device — so the flattened row's
+        browser must come from the session, not the device."""
+        view = BaseOpenIDConnectViewset.as_view({"get": "sessions_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        upstream.json.return_value = [
+            {
+                "os": "macOS",
+                "current": True,
+                "sessions": [
+                    {
+                        "id": "sess-1",
+                        "browser": "Chrome",
+                        "ipAddress": "1.2.3.4",
+                        "started": 1715520000,
+                        "lastAccess": 1715526000,
+                        "current": True,
+                        "clients": [{"clientId": "example"}],
+                    }
+                ],
+            },
+            {
+                "os": "Windows",
+                "current": False,
+                "sessions": [
+                    {
+                        "id": "sess-2",
+                        "browser": "Firefox",
+                        "ipAddress": "5.6.7.8",
+                        "started": 1715500000,
+                        "lastAccess": 1715505000,
+                        "current": False,
+                        "clients": [{"clientId": "example"}],
+                    }
+                ],
+            },
+        ]
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        rows = response.data
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["id"], "sess-1")
+        self.assertEqual(rows[0]["browser"], "Chrome")
+        self.assertEqual(rows[0]["os"], "macOS")
+        self.assertTrue(rows[0]["current"])
+        self.assertEqual(rows[1]["id"], "sess-2")
+        self.assertEqual(rows[1]["browser"], "Firefox")
+        self.assertEqual(rows[1]["os"], "Windows")
+        self.assertFalse(rows[1]["current"])
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_list_marks_only_sid_match_current_when_grouped(self):
+        """Two browsers on one machine (e.g. normal + incognito on
+        localhost) collapse into a single device that Keycloak flags
+        ``current``, with both nested sessions flagged ``current`` too.
+        Only the session whose id matches the id_token ``sid`` should
+        render as current — not both."""
+        view = BaseOpenIDConnectViewset.as_view({"get": "sessions_list"})
+        request = self.factory.get("/")
+        request.session = {
+            "oidc_access_token": "stashed.access.token",
+            "oidc_id_token": "stashed.id.token",
+        }
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        upstream.json.return_value = [
+            {
+                "browser": "Chrome",
+                "os": "Mac OS X",
+                "current": True,
+                "sessions": [
+                    {"id": "sess-old", "current": True, "clients": []},
+                    {"id": "sess-current", "current": True, "clients": []},
+                ],
+            },
+        ]
+        with (
+            patch("oidc.viewsets._sid_from_id_token", return_value="sess-current"),
+            patch("oidc.client.requests.request", return_value=upstream),
+        ):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        by_id = {row["id"]: row for row in response.data}
+        self.assertFalse(by_id["sess-old"]["current"])
+        self.assertTrue(by_id["sess-current"]["current"])
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_revoke_one_forwards_id(self):
+        view = BaseOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
+        request = self.factory.delete("/")
+        request.session = {
+            "oidc_access_token": "stashed.access.token",
+            "oidc_id_token": "header.payload.sig",
+        }
+        upstream = MagicMock(status_code=204, content=b"")
+        with (
+            patch("oidc.viewsets._sid_from_id_token", return_value="current-sid"),
+            patch(
+                "oidc.client.requests.request", return_value=upstream
+            ) as mock_request,
+        ):
+            response = view(request, auth_server="default", session_id="other-sid")
+
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertEqual(args[0], "DELETE")
+        self.assertTrue(args[1].endswith("/sessions/other-sid"))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_revoke_one_rejects_current_session(self):
+        view = BaseOpenIDConnectViewset.as_view({"delete": "sessions_revoke_one"})
+        request = self.factory.delete("/")
+        request.session = {
+            "oidc_access_token": "stashed.access.token",
+            "oidc_id_token": "header.payload.sig",
+        }
+        with (
+            patch("oidc.viewsets._sid_from_id_token", return_value="current-sid"),
+            patch("oidc.client.requests.request") as mock_request,
+        ):
+            response = view(request, auth_server="default", session_id="current-sid")
+
+        self.assertEqual(response.status_code, 409)
+        # Crucial: we never reach Keycloak.
+        mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_sessions_revoke_others_passes_current_false(self):
+        """DELETE /sessions revokes every session EXCEPT the current one."""
+        view = BaseOpenIDConnectViewset.as_view({"delete": "sessions_revoke_others"})
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=204, content=b"")
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            response = view(request, auth_server="default")
+
+        # 204 No Content is Keycloak's natural success code for DELETE;
+        # passed through verbatim so the SPA can treat `res.ok` uniformly.
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertEqual(args[0], "DELETE")
+        self.assertIn("/sessions?current=false", args[1])
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_list_forwards_keycloak_body_verbatim(self):
+        view = BaseOpenIDConnectViewset.as_view({"get": "linked_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        keycloak_body = [
+            {
+                "providerAlias": "google",
+                "providerName": "Google",
+                "displayName": "Google",
+                "connected": True,
+                "social": True,
+                "linkedUsername": "alice@gmail.com",
+            }
+        ]
+        upstream.json.return_value = keycloak_body
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, keycloak_body)
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_unlink_forwards_provider_alias(self):
+        view = BaseOpenIDConnectViewset.as_view({"delete": "linked_unlink"})
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+        upstream = MagicMock(status_code=204, content=b"")
+        with patch(
+            "oidc.client.requests.request", return_value=upstream
+        ) as mock_request:
+            response = view(request, auth_server="default", provider="google")
+        self.assertEqual(response.status_code, 204)
+        args, _ = mock_request.call_args
+        self.assertTrue(args[1].endswith("/linked-accounts/google"))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_unlink_rejects_invalid_provider_alias(self):
+        view = BaseOpenIDConnectViewset.as_view({"delete": "linked_unlink"})
+        request = self.factory.delete("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+        with patch("oidc.client.requests.request") as mock_request:
+            response = view(request, auth_server="default", provider="../etc/passwd")
+        self.assertEqual(response.status_code, 400)
+        mock_request.assert_not_called()
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_linked_link_url_forwards_body(self):
+        """The link-url action forwards Keycloak's linked-account
+        representation verbatim — the SPA extracts ``accountLinkUri``
+        client-side."""
+        view = BaseOpenIDConnectViewset.as_view({"get": "linked_link_url"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"{...}"
+        upstream.json.return_value = {
+            "accountLinkUri": "https://idp.example.com/realms/r/broker/google/link?nonce=n&hash=h",
+            "nonce": "n",
+            "hash": "h",
+        }
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default", provider="google")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "accountLinkUri": (
+                    "https://idp.example.com/realms/r/broker/google/link"
+                    "?nonce=n&hash=h"
+                ),
+                "nonce": "n",
+                "hash": "h",
+            },
+        )
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_credentials_list_forwards_body(self):
+        """The credentials action forwards Keycloak's nested
+        credential-metadata wire shape verbatim — reshaping for
+        rendering (flattening ``userCredentialMetadatas`` →
+        ``credential``) happens client-side in the SPA."""
+        view = BaseOpenIDConnectViewset.as_view({"get": "credentials_list"})
+        request = self.factory.get("/")
+        request.session = {"oidc_access_token": "stashed.access.token"}
+
+        upstream_body = [
+            {
+                "type": "otp",
+                "category": "two-factor",
+                "displayName": "otp-display-name",
+                "userCredentialMetadatas": [
+                    {
+                        "credential": {
+                            "id": "cred-1",
+                            "type": "otp",
+                            "userLabel": "iPhone",
+                            "createdDate": 1715000000000,
+                        }
+                    }
+                ],
+            },
+            {
+                "type": "password",
+                "category": "basic-authentication",
+                "displayName": "password-display-name",
+                "userCredentialMetadatas": [
+                    {"credential": {"id": "cred-pw", "type": "password"}}
+                ],
+            },
+        ]
+        upstream = MagicMock(status_code=200)
+        upstream.content = b"[...]"
+        upstream.json.return_value = upstream_body
+        with patch("oidc.client.requests.request", return_value=upstream):
+            response = view(request, auth_server="default")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, upstream_body)
+
     @patch(
         "oidc.viewsets.OpenIDClient.verify_and_decode_id_token",
         MagicMock(
@@ -1792,6 +2376,62 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(cookie["max-age"], 0)
 
 
+class TestAccountRoutes(TestCase):
+    """URL→action wiring smoke test; per-action behaviour is covered
+    by the per-action tests above."""
+
+    ROUTES = (
+        ("/oidc/example/account", "post", "account", {}),
+        ("/oidc/example/sessions", "get", "sessions_list", {}),
+        ("/oidc/example/sessions", "delete", "sessions_revoke_others", {}),
+        (
+            "/oidc/example/sessions/abc-123",
+            "delete",
+            "sessions_revoke_one",
+            {"session_id": "abc-123"},
+        ),
+        ("/oidc/example/linked-accounts", "get", "linked_list", {}),
+        (
+            "/oidc/example/linked-accounts/google",
+            "delete",
+            "linked_unlink",
+            {"provider": "google"},
+        ),
+        (
+            "/oidc/example/linked-accounts/google/link-url",
+            "get",
+            "linked_link_url",
+            {"provider": "google"},
+        ),
+        ("/oidc/example/credentials", "get", "credentials_list", {}),
+    )
+
+    def test_routes_resolve_to_their_actions(self):
+        for path, method, action, url_kwargs in self.ROUTES:
+            with self.subTest(path=path, method=method):
+                match = resolve(path)
+                self.assertEqual(match.func.actions[method], action)
+                for key, value in url_kwargs.items():
+                    self.assertEqual(match.kwargs[key], value)
+
+    def test_account_proxy_routes_carry_the_csrf_permission(self):
+        """The gate is applied in ``urls.py``, not on the viewset, so a proxy
+        route added without ``_ACCOUNT_PROXY_VIEW_KWARGS`` would be unguarded.
+
+        Both keys matter: empty ``authentication_classes`` is what takes these
+        routes out of DRF's SessionAuthentication/CSRF path, and the permission
+        is what replaces it. Either one alone is a hole.
+        """
+        for path in {route[0] for route in self.ROUTES}:
+            with self.subTest(path=path):
+                initkwargs = resolve(path).func.initkwargs
+                self.assertIn(
+                    RequireAccountRequestHeader,
+                    initkwargs.get("permission_classes", []),
+                )
+                self.assertEqual(initkwargs.get("authentication_classes"), [])
+
+
 class TestLoginNextValidation(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
@@ -2205,3 +2845,96 @@ class TestSessionAction(TestCase):
         )
         self.assertEqual(response.status_code, 401)
         self.assertFalse(response.has_header("WWW-Authenticate"))
+
+
+class AccountProxyCsrfTests(TestCase):
+    """CSRF gate on the state-changing account-proxy actions: unsafe methods
+    require a custom header AND a trusted Origin."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.perm = RequireAccountRequestHeader()
+        self.view = SimpleNamespace(kwargs={"auth_server": "default"})
+        self.header_kwarg = {
+            "HTTP_" + ACCOUNT_REQUEST_HEADER.upper().replace("-", "_"): "1"
+        }
+
+    def test_safe_method_exempt(self):
+        """GET/HEAD/OPTIONS need neither header nor origin."""
+        self.assertTrue(self.perm.has_permission(self.factory.get("/"), self.view))
+
+    def test_unsafe_without_header_denied(self):
+        """POST/DELETE without the header are refused by the permission."""
+        self.assertFalse(self.perm.has_permission(self.factory.post("/"), self.view))
+        self.assertFalse(self.perm.has_permission(self.factory.delete("/"), self.view))
+
+    def test_unsafe_with_header_no_origin_allowed(self):
+        """Header + no Origin (same-origin requests may omit it) → allowed."""
+        request = self.factory.post("/", **self.header_kwarg)
+        self.assertTrue(self.perm.has_permission(request, self.view))
+
+    def test_unsafe_same_origin_allowed(self):
+        """Header + the request's own origin → allowed."""
+        request = self.factory.post(
+            "/", HTTP_ORIGIN="http://testserver", **self.header_kwarg
+        )
+        self.assertTrue(self.perm.has_permission(request, self.view))
+
+    def test_unsafe_untrusted_origin_denied(self):
+        """Header present but a foreign Origin → refused. This is the layer
+        that holds even if the deployment's CORS is permissive."""
+        request = self.factory.post(
+            "/", HTTP_ORIGIN="https://evil.example", **self.header_kwarg
+        )
+        self.assertFalse(self.perm.has_permission(request, self.view))
+
+    def test_unsafe_null_origin_denied(self):
+        """Origin: null (sandboxed iframe / opaque origin) is host-less and
+        must not be treated as same-origin-safe."""
+        request = self.factory.post("/", HTTP_ORIGIN="null", **self.header_kwarg)
+        self.assertFalse(self.perm.has_permission(request, self.view))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "LOGIN_REDIRECT_ALLOWED_HOSTS": ["app.example.com"],
+            },
+        }
+    )
+    def test_unsafe_allowlisted_cross_origin_allowed(self):
+        """A configured SPA origin (via LOGIN_REDIRECT_ALLOWED_HOSTS) → ok."""
+        request = self.factory.post(
+            "/", HTTP_ORIGIN="https://app.example.com", **self.header_kwarg
+        )
+        self.assertTrue(self.perm.has_permission(request, self.view))
+
+    @override_settings(
+        OPENID_CONNECT_AUTH_SERVERS={
+            **OPENID_CONNECT_AUTH_SERVERS,
+            "default": {
+                **OPENID_CONNECT_AUTH_SERVERS["default"],
+                "ACCOUNT_ENDPOINT": "https://idp.example.com/realms/r/account",
+            },
+        },
+        OPENID_CONNECT_VIEWSET_CONFIG=OPENID_CONNECT_VIEWSET_CONFIG,
+    )
+    def test_permitted_request_reaches_the_action(self):
+        """Header + no cross-origin Origin: the permission passes and the
+        action runs through to a concrete success."""
+        view = BaseOpenIDConnectViewset.as_view(
+            {"post": "account"},
+            authentication_classes=[],
+            permission_classes=[RequireAccountRequestHeader],
+        )
+        request = self.factory.post(
+            "/", data={"firstName": "X"}, format="json", **self.header_kwarg
+        )
+        request.session = {"oidc_access_token": "t"}
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.content = b""
+        with patch("oidc.client.requests.request", return_value=mock_response):
+            response = view(request, auth_server="default")
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -20,16 +20,20 @@ from rest_framework.test import APIRequestFactory
 
 from oidc.client import OpenIDClient, TokenVerificationFailed, state_cache_key
 from oidc.permissions import IsCsrfSafeAccountRequest, get_account_request_header
+from oidc.urls import get_viewset_class
+from tests.project_viewsets import InjectedViewset
 from oidc.viewsets import (
     DEFAULT_USERNAME_HELP_TEXT,
     DEFAULT_USERNAME_PATTERN,
     USERNAME_FORM_MARKER_FIELD,
     USERNAME_FORM_MARKER_VALUE,
     BaseOpenIDConnectViewset,
+    RapidProOpenIDConnectViewset,
     UserModelOpenIDConnectViewset,
 )
 
 User = get_user_model()
+
 
 OPENID_CONNECT_AUTH_SERVERS = {
     "default": {
@@ -2469,6 +2473,59 @@ class TestUserModelOpenIDConnectViewset(TestCase):
         self.assertEqual(cookie["path"], "/admin")
         self.assertEqual(cookie["samesite"], "Strict")
         self.assertEqual(cookie["max-age"], 0)
+
+
+class TestViewsetClassInjection(TestCase):
+    """Which viewset ``oidc.urls`` routes to.
+
+    Without injection a deployment that needs its own subclass has to copy the
+    whole URLconf, then mirror every future route and view kwarg by hand.
+    """
+
+    def test_defaults_to_the_user_model_viewset(self):
+        self.assertIs(get_viewset_class(), UserModelOpenIDConnectViewset)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "USE_RAPIDPRO_VIEWSET": True,
+        }
+    )
+    def test_rapidpro_boolean_still_honoured(self):
+        """Back-compat: the older boolean form keeps working."""
+        self.assertIs(get_viewset_class(), RapidProOpenIDConnectViewset)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.InjectedViewset",
+        }
+    )
+    def test_dotted_path_routes_to_a_project_subclass(self):
+        self.assertIs(get_viewset_class(), InjectedViewset)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.InjectedViewset",
+            "USE_RAPIDPRO_VIEWSET": True,
+        }
+    )
+    def test_dotted_path_wins_over_the_boolean(self):
+        """Pin the precedence: a deployment that names a class means it."""
+        self.assertIs(get_viewset_class(), InjectedViewset)
+
+    @override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={
+            **OPENID_CONNECT_VIEWSET_CONFIG,
+            "VIEWSET_CLASS": "tests.project_viewsets.NoSuchViewset",
+        }
+    )
+    def test_unimportable_path_fails_loudly(self):
+        """A typo must not silently fall back to the default viewset — that
+        would drop a subclass's access rules with nothing to notice it."""
+        with self.assertRaises(ImportError):
+            get_viewset_class()
 
 
 class TestAccountRoutes(TestCase):


### PR DESCRIPTION
Stacked on #124 (`feat/account-proxy-and-logout-extra-params`) — review that first; the diff here is only the routing change. **Merge #124 before this.**

## Why

Follow-up to the review comment on #124 asking whether the account-proxy view kwargs belong on the viewset rather than in `urls.py`. They do — but `@action(permission_classes=...)` is silently ignored without a router, so answering that required a router first.

`urls.py`: **118 → 46 lines**. `_ACCOUNT_PROXY_VIEW_KWARGS` is gone; the CSRF gate now lives on the seven proxy actions, so a subclassing consumer inherits it.

```python
router = UnprefixedNameRouter(trailing_slash=False)
router.register(r"oidc/(?P<auth_server>\w+)", get_viewset_class(), basename="oidc")
urlpatterns = router.urls
```

## Routing is unchanged

Every route was dumped before and after — pattern, name, method map and view kwargs — and diffed. All 11 patterns, all names, all method maps and all kwarg sets are identical. 166/166 tests pass.

Three things had to be solved to get there.

**Route names.** A stock router names every route `{basename}-{url_name}`, which would have turned `reverse("oidc:openid_connect_login")` into `reverse("oidc:oidc-openid_connect_login")` — a public API break affecting this package's own error page and every consumer, including onadata, where onaio/onadata#3090 explicitly preserved that name. `UnprefixedNameRouter` (`oidc/routers.py`, 20 lines) strips the `{basename}-` prefix from DRF's route templates, so the names carry over exactly.

**`/sessions` is served by two actions.** `sessions_list` (GET) and `sessions_revoke_others` (DELETE) share one path. A router builds one route per action, so both got the same pattern and Django resolved the first — whose action map has no `delete`. `DELETE /oidc/x/sessions` would have returned **405, silently**. Fixed with `@sessions_list.mapping.delete`: one route, both methods.

**Trailing slashes.** `SimpleRouter` anchors its patterns, but `login`, `logout` and `callback` were previously unanchored (`^…/login`, no `$`), so `/login/` matched. `callback` is the OIDC `redirect_uri` — registered with the identity provider outside this codebase — so a deployment that registered the trailing-slash form would have started 404ing mid-authentication, with nothing here to catch it. Those three actions take `url_path="<name>/?"`, which accepts both forms and still reverses to the slash-free one.

## Not done

- README note that `VIEWSET_CLASS` consumers now inherit view kwargs from the actions
