### PR TITLE
fix: make str_to_bool coerce the string spellings of false

### DIFF
--- a/oidc/utils.py
+++ b/oidc/utils.py
@@ -42,8 +42,15 @@ def authenticate_sso(request, unique_user_field: str = "email"):
 
 
 def str_to_bool(val):
+    """Coerce a settings value that may have come from the environment.
+
+    Only the exact literal ``"False"`` was falsy, so ``"false"`` -- what
+    ``os.getenv("X", "false")`` yields -- read as True. Several settings
+    fail open that way: ``AUTO_CREATE_USER`` and the admin import switch
+    both turn *on* when spelled off.
+    """
     if isinstance(val, str):
-        val = 0 if val == "False" else 1
+        return val.strip().lower() not in ("false", "0", "", "no", "off")
     return val
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from rest_framework.test import APIRequestFactory
 from oidc.utils import (
     get_login_query_param_allowlist,
     is_safe_login_redirect,
+    str_to_bool,
 )
 
 
@@ -26,9 +27,7 @@ class TestGetLoginQueryParamAllowlist(TestCase):
             frozenset({"prompt", "ui_locales"}),
         )
 
-    @override_settings(
-        OPENID_CONNECT_AUTH_SERVERS={"default": {"CLIENT_ID": "client"}}
-    )
+    @override_settings(OPENID_CONNECT_AUTH_SERVERS={"default": {"CLIENT_ID": "client"}})
     def test_returns_empty_when_key_missing(self):
         self.assertEqual(get_login_query_param_allowlist("default"), frozenset())
 
@@ -100,9 +99,7 @@ class TestIsSafeLoginRedirect(TestCase):
 
     def test_javascript_scheme_is_unsafe(self):
         self.assertFalse(
-            is_safe_login_redirect(
-                "javascript:alert(1)", "default", self._request()
-            )
+            is_safe_login_redirect("javascript:alert(1)", "default", self._request())
         )
 
     def test_protocol_relative_url_is_unsafe(self):
@@ -122,3 +119,26 @@ class TestIsSafeLoginRedirect(TestCase):
             is_safe_login_redirect(
                 "https://spa.example.com/x", "default", self._request()
             )
+
+
+class TestStrToBool(TestCase):
+    """Settings arrive from the environment as strings. Only the exact
+    literal ``"False"`` used to be falsy, so the spelling ``os.getenv``
+    hands you turned several switches *on*: ``AUTO_CREATE_USER`` created
+    the users it was set to refuse, ``USE_SSO_COOKIE`` issued the identity
+    cookie anyway, and the admin's user-import screen enabled itself."""
+
+    def test_the_spellings_of_off_are_all_false(self):
+        for value in ("False", "false", "FALSE", "0", "", "no", "off", " false "):
+            with self.subTest(value=value):
+                self.assertFalse(str_to_bool(value))
+
+    def test_the_spellings_of_on_stay_true(self):
+        for value in ("True", "true", "1", "yes", "on"):
+            with self.subTest(value=value):
+                self.assertTrue(str_to_bool(value))
+
+    def test_non_strings_pass_through(self):
+        self.assertIs(str_to_bool(True), True)
+        self.assertIs(str_to_bool(False), False)
+        self.assertIsNone(str_to_bool(None))


### PR DESCRIPTION
### Changes / Features implemented

`str_to_bool` treats only the exact literal `"False"` as falsy. `"false"`, `"0"`, `""`,
`"no"` and `"off"` all coerce to **True** — the opposite of what they mean. The function
exists specifically to coerce strings, so this is squarely within its job.

Now falsy on all of those, case- and whitespace-insensitive. Non-strings pass through
unchanged.

### Is this reachable today?

**No — and reviewers should weigh it on that basis.** I checked every path:

| | |
|---|---|
| Call sites | All 8 read `config.get(KEY, <default>)` |
| Package defaults (`oidc/settings.py`) | Real bools — `"AUTO_CREATE_USER": True`, `"ENABLED": True` |
| onadata `common.py` | Real bools — `"USE_SSO_COOKIE": True`, `"USE_AUTH_BACKEND": False` |

Nothing currently passes a string, so the buggy branch is unreachable. This is
defensive hardening for a published library, not a fix for an observed failure.

Where it *would* bite: a consumer wiring config from the environment, e.g.
`"AUTO_CREATE_USER": os.getenv("OIDC_AUTO_CREATE_USER", "false")`. That silently
enables the flag it was set to disable, with no error.

Salvaged from #124, which is being retired — independent of that PR's Keycloak account
proxy. Happy to close this if the team would rather not carry hardening for a case no
current consumer hits.

### Steps taken to verify this change does what is intended

- 3 new tests: the spellings of off, the spellings of on, non-string pass-through
- full suite: 132 tests, all passing
- flake8 clean

### Side effects of implementing this change

None for a deployment passing real booleans, which is all of them today. If a
deployment *were* passing one of these strings, it has been getting the opposite of
what it configured and merging this would flip that behaviour — worth a glance at env
values before rolling out.

The two reformatting hunks in `tests/test_utils.py` are `black` bringing the file into
compliance; `main` is not currently black-clean there.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation — n/a
