### PR TITLE
fix: ship a base.html so the browser-facing pages render on a fresh install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ INSTALLED_APPS = [
 
 ```
 
+The username-entry form and the error page extend `base.html`, and the
+package ships a plain one so a fresh install renders. To use your own,
+put it on `TEMPLATES["DIRS"]` or in an app listed before `oidc`; it only
+needs `title` and `content` blocks.
+
 3. Set `OPENID_CONNECT_VIEWSET_CONFIG` and `OPENID_CONNECT_AUTH_SERVERS` settings
 
 ```python

--- a/oidc/templates/base.html
+++ b/oidc/templates/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+{% comment %}
+Fallback only. The two pages this package renders in a browser -- the
+username-entry form and the unrecoverable-error page -- extend 'base.html',
+and without one anywhere on the template path they raise
+TemplateDoesNotExist and the user gets a bare 500 instead.
+
+A project's own base.html wins: TEMPLATES["DIRS"] is searched before any app
+directory, and among app directories the INSTALLED_APPS order decides, so
+list "oidc" after the app that provides yours. It only has to define the
+title and content blocks below.
+{% endcomment %}
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}{% endblock %}</title>
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/oidc/templates/oidc/oidc_unrecoverable_error.html
+++ b/oidc/templates/oidc/oidc_unrecoverable_error.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="content">
     <div class="content-body">
-        <p class="error-message">{{ error }}</a></p>
+        <p class="error-message">{{ error }}</p>
         {% if login_url %}
         <p>Something went wrong, please try again later - <a href="{{ login_url }}">login</a>.</p>
         {% endif %}

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -3,7 +3,8 @@
 Test that oidc urls resolve.
 """
 
-from django.test import TestCase
+from django.template.loader import get_template
+from django.test import TestCase, override_settings
 from django.urls import resolve, reverse
 
 from rest_framework.renderers import JSONRenderer
@@ -47,3 +48,29 @@ class TestUrls(TestCase):
         self.assertEqual(view.actions, {"get": "session"})
         self.assertEqual(view.initkwargs["authentication_classes"], [])
         self.assertEqual(view.initkwargs["renderer_classes"], [JSONRenderer])
+
+
+class TestShippedTemplatesRenderStandalone(TestCase):
+    """The package renders two pages in a browser, and both extend
+    ``base.html``. The suite puts a fixture one on ``DIRS``, so nothing here
+    exercised what a project that installed the package and followed the
+    README actually gets -- which was TemplateDoesNotExist, i.e. a bare 500
+    on the username form and on every unrecoverable-error page."""
+
+    @override_settings(
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "DIRS": [],
+                "APP_DIRS": True,
+                "OPTIONS": {"context_processors": []},
+            }
+        ]
+    )
+    def test_they_render_with_app_dirs_alone(self):
+        for name in (
+            "oidc/oidc_unrecoverable_error.html",
+            "oidc/oidc_user_data_entry.html",
+        ):
+            with self.subTest(template=name):
+                get_template(name).render({})


### PR DESCRIPTION
### Changes / Features implemented

The two pages this package renders in a browser — the username-entry form and the
unrecoverable-error page — both `{% extends 'base.html' %}`, but no `base.html` was
shipped. A project that installed the package and followed the README got
`TemplateDoesNotExist`: a bare 500 on both.

Adds a plain `oidc/templates/base.html` with just `title` and `content` blocks. A
project's own still wins — `TEMPLATES["DIRS"]` is searched before any app directory,
and among app directories `INSTALLED_APPS` order decides.

Also closes a stray `</a>` in the error template's error-message paragraph.

Salvaged from #124, which is being retired — independent of that PR's Keycloak
account proxy.

### Steps taken to verify this change does what is intended

The suite never caught this because `tests/settings.py` puts a fixture `base.html` on
`TEMPLATES["DIRS"]`, so nothing exercised what a fresh install has. The new test
renders both templates with `DIRS` empty and `APP_DIRS` alone.

- confirmed it bites: with `base.html` removed the new test fails with
  `TemplateDoesNotExist: base.html`
- full suite: 130 tests, all passing

### Side effects of implementing this change

A project that already provides its own `base.html` is unaffected — theirs still
resolves first. A project relying on the 500 (nobody, presumably) now gets a rendered
page.

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [x] Updated documentation