### PR TITLE
fix: point long_description at the README that exists, stop shipping tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,8 @@
 name = ona-oidc
 version = 2.10.0
 description = Ona OpenID Connect Client
-long_description = file: README.rst
-long_description_content_type = text/x-rst
+long_description = file: README.md
+long_description_content_type = text/markdown
 url = https://github.com/onaio/ona-oidc
 author = Ona Systems Inc
 author_email = support@ona.io
@@ -42,7 +42,7 @@ setup_requires =
     setuptools_scm
 
 [options.packages.find]
-exclude = tests
+exclude = tests, tests.*
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
### Changes / Features implemented

Two packaging defects, both visible in a built wheel.

**1. `long_description = file: README.rst`** names a file this repo does not have —
it ships `README.md`. setuptools does not fail on a missing long_description file, it
just emits nothing, so the wheel's METADATA carries an empty description with
`Description-Content-Type: text/x-rst`. The package page has been blank.

**2. `exclude = tests`** under `[options.packages.find]` only excludes the *top-level*
`tests` package, not its subpackages. `tests.admin` was therefore installed into
site-packages as a top-level `tests` module — any project installing ona-oidc gets an
importable `tests` package that can collide with its own.

Salvaged from #124, which is being retired — independent of that PR's Keycloak
account proxy.

### Steps taken to verify this change does what is intended

Built the wheel both ways from a clean tree — a stale `build/` or `ona_oidc.egg-info`
masks this, which is likely why it went unnoticed:

| setup.cfg | wheel contents |
|---|---|
| `exclude = tests` | `tests/admin/__init__.py`, `tests/admin/urls.py`, … |
| `exclude = tests, tests.*` | no `tests` entries; top level is `oidc/` alone |
| `file: README.rst` | description **0 chars**, `text/x-rst` |
| `file: README.md` | description **9348 chars**, `text/markdown` |

Full suite: 129 tests, all passing (no behaviour change).

### Side effects of implementing this change

A deployment that (accidentally) imported the installed `tests` package would break —
but that package was ona-oidc's own test fixtures, so nothing should be importing it.

The next release will have a populated package description for the first time.

**Before submitting this PR for review, please make sure you have:**

  - [ ] Included tests — n/a, packaging metadata; verified by inspecting built wheels
  - [ ] Updated documentation — n/a