### PR TITLE
refactor: build the URLconf from @action, add a subclass deploy check

### DIFF
--- a/oidc/apps.py
+++ b/oidc/apps.py
@@ -3,6 +3,7 @@ Application Module for oidc app
 """
 
 from django.apps import AppConfig
+from django.core.checks import register
 from django.utils.translation import gettext_lazy as _
 
 
@@ -14,3 +15,11 @@ class oidcConfig(AppConfig):
     name = "oidc"
     app_label = "oidc"
     verbose_name = _("OpenID Connect")
+
+    def ready(self):
+        # Imported here rather than at module scope: the check pulls in the
+        # viewsets, which read settings, and that must not happen while the
+        # app registry is still populating.
+        from oidc.checks import check_actions_survive_subclassing
+
+        register(check_actions_survive_subclassing)

--- a/oidc/checks.py
+++ b/oidc/checks.py
@@ -1,0 +1,136 @@
+"""
+Deployment checks for the oidc app.
+
+Registered from ``oidcConfig.ready``, so they run on ``manage.py check``,
+``migrate``, ``runserver`` and any other management command -- i.e. at
+deploy time rather than on the first user who tries to sign in.
+"""
+
+from django.core.checks import Error
+
+#: View kwargs an override has to carry forward. Dropping ``permission_classes``
+#: falls back to the viewset default -- ``AllowAny`` -- which silently
+#: removes whatever gate the base declared, while the route still looks
+#: identical by path, name and verb. Compared as subsets so a subclass may
+#: add to them.
+_GUARDED_VIEW_KWARGS = (
+    "permission_classes",
+    "authentication_classes",
+    "renderer_classes",
+)
+
+
+def _required_classes(entry) -> set:
+    """Everything an entry demands unconditionally.
+
+    ``A & B`` does not keep both classes in the list -- DRF builds a single
+    ``OperandHolder`` -- so a subclass that *tightened* a route by composing
+    would look, to a plain membership test, exactly like one that dropped
+    the gate. Only ``AND`` is flattened: ``A | B`` is a weakening, and has
+    to be reported.
+    """
+    operator = getattr(entry, "operator_class", None)
+    if operator is not None and operator.__name__ == "AND":
+        return _required_classes(entry.op1_class) | _required_classes(entry.op2_class)
+    return {entry}
+
+
+def _kwarg_survives(inherited, current, key: str) -> bool:
+    """Whether the override still demands everything the parent declared.
+
+    Presence is checked before content: ``authentication_classes=[]`` is
+    declared empty on purpose, and an empty set is a subset of anything --
+    including of an override that dropped the kwarg entirely and inherited
+    DRF's session and basic auth, CSRF enforcement and all.
+    """
+    declared = getattr(inherited, "kwargs", {})
+    if key not in declared:
+        return True
+    kept = getattr(current, "kwargs", {})
+    if key not in kept:
+        return False
+    required = set().union(*(_required_classes(e) for e in kept[key] or ())) or set()
+    return set(declared[key] or ()) <= required
+
+
+def _hint_kwargs(inherited) -> str:
+    """The guarded view kwargs, spelled out so the hint can be copied."""
+    declared = [
+        f"{key}={[c.__name__ for c in getattr(inherited, 'kwargs', {})[key]]}"
+        for key in _GUARDED_VIEW_KWARGS
+        if key in getattr(inherited, "kwargs", {})
+    ]
+    return ", ".join(declared) if declared else "its view kwargs"
+
+
+def _routes_match(inherited, current) -> bool:
+    """Whether an override still produces the route its parent declared.
+
+    Name equality is not enough: a re-declared decorator with a different
+    ``url_path`` moves the endpoint, ``detail=True`` moves it again by
+    adding a ``pk`` segment, a different ``url_name`` breaks ``reverse()``,
+    a fresh ``MethodMapper`` silently drops any ``@<action>.mapping.<verb>``
+    companion the parent had, and omitted view kwargs quietly widen who may
+    call it.
+
+    The mapping is compared by verb rather than by (verb, handler name): the
+    route carries the verbs, so renaming the method a companion points at is
+    a rename, not a lost route.
+    """
+    return (
+        getattr(inherited, "url_path", None) == getattr(current, "url_path", None)
+        and getattr(inherited, "url_name", None) == getattr(current, "url_name", None)
+        and getattr(inherited, "detail", None) == getattr(current, "detail", None)
+        and inherited.mapping.keys() <= current.mapping.keys()
+        and all(
+            _kwarg_survives(inherited, current, key) for key in _GUARDED_VIEW_KWARGS
+        )
+    )
+
+
+def check_actions_survive_subclassing(app_configs, **kwargs):
+    """Catch a subclass that overrode an ``@action`` without re-declaring it.
+
+    The router builds routes from the ``@action`` metadata attached to the
+    function. A plain override replaces the function and drops that
+    metadata, so the route is never generated -- the endpoint 404s with
+    nothing to indicate why. Silent, and only reachable through
+    ``VIEWSET_CLASS``, so it belongs at deploy time.
+    """
+    from oidc.urls import get_viewset_class
+
+    try:
+        viewset_class = get_viewset_class()
+    except Exception:  # pragma: no cover - a broken VIEWSET_CLASS is its own error
+        return []
+
+    routed = {action.__name__: action for action in viewset_class.get_extra_actions()}
+    errors = []
+    for klass in viewset_class.__mro__[1:]:
+        for name, inherited in vars(klass).items():
+            if not hasattr(inherited, "mapping"):
+                continue
+            current = routed.get(name)
+            if current is not None and _routes_match(inherited, current):
+                continue
+            errors.append(
+                Error(
+                    f"{viewset_class.__name__}.{name}() overrides the @action "
+                    f"declared on {klass.__name__} without preserving its "
+                    f"route.",
+                    hint=(
+                        f"Re-apply the decorator on the override, matching "
+                        f"{klass.__name__}.{name} exactly: url_path="
+                        f"{getattr(inherited, 'url_path', None)!r}, url_name="
+                        f"{getattr(inherited, 'url_name', None)!r}, detail="
+                        f"{getattr(inherited, 'detail', None)!r}, at least the "
+                        f"methods {sorted(inherited.mapping)}, and "
+                        f"{_hint_kwargs(inherited)}. Any @{name}.mapping.<verb> "
+                        f"companions must be re-declared too -- a fresh "
+                        f"decorator replaces them."
+                    ),
+                    id="oidc.E002",
+                )
+            )
+            routed[name] = inherited  # don't report the same name twice
+    return errors

--- a/oidc/routers.py
+++ b/oidc/routers.py
@@ -1,0 +1,31 @@
+"""
+Routers used to build this package's URLs.
+"""
+
+from rest_framework.routers import DynamicRoute, SimpleRouter
+
+
+class UnprefixedNameRouter(SimpleRouter):
+    """A router that names ``@action`` routes ``{url_name}``, not
+    ``{basename}-{url_name}``.
+
+    ``reverse("oidc:openid_connect_login")`` is part of this package's public
+    surface — used by the unrecoverable-error template and by consumers — so
+    the names the hand-written URLconf declared have to survive. A stock
+    router would rename that route to ``oidc-openid_connect_login``.
+
+    Only the dynamic routes: every name this package publishes comes from an
+    ``@action``, while ``{basename}-list``/``-detail`` belong to DRF's own
+    conventions. Stripping those too would rename a ``VIEWSET_CLASS`` with
+    CRUD methods to a bare ``list``/``detail``, which collides across
+    routers and breaks hyperlinked serializers reversing ``<model>-detail``.
+    """
+
+    routes = [
+        (
+            route._replace(name=route.name.replace("{basename}-", ""))
+            if isinstance(route, DynamicRoute)
+            else route
+        )
+        for route in SimpleRouter.routes
+    ]

--- a/oidc/urls.py
+++ b/oidc/urls.py
@@ -3,44 +3,38 @@ URL Configuration file for ona-oidc
 """
 
 from django.conf import settings
-from django.urls import re_path
+from django.utils.module_loading import import_string
 
-from rest_framework.renderers import JSONRenderer
-
+from oidc.routers import UnprefixedNameRouter
 from oidc.utils import str_to_bool
 from oidc.viewsets import RapidProOpenIDConnectViewset, UserModelOpenIDConnectViewset
 
 app_name = "oidc"
 
-viewset_class = UserModelOpenIDConnectViewset
 
-config = getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", {})
-if str_to_bool(config.get("USE_RAPIDPRO_VIEWSET", False)):
-    viewset_class = RapidProOpenIDConnectViewset
+def get_viewset_class():
+    """The viewset these URLs route to.
 
-urlpatterns = [
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/login",
-        viewset_class.as_view({"get": "login"}),
-        name="openid_connect_login",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/callback",
-        viewset_class.as_view({"get": "callback", "post": "callback"}),
-        name="openid_connect_callback",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/logout",
-        viewset_class.as_view({"get": "logout"}),
-        name="openid_connect_logout",
-    ),
-    re_path(
-        r"^oidc/(?P<auth_server>\w+)/session",
-        viewset_class.as_view(
-            {"get": "session"},
-            authentication_classes=[],
-            renderer_classes=[JSONRenderer],
-        ),
-        name="openid_connect_session",
-    ),
-]
+    ``VIEWSET_CLASS`` (a dotted path) lets a deployment route to its own
+    subclass while still using ``include("oidc.urls")``. Without it, changing
+    this one name means copying the whole URLconf, and then mirroring every
+    route by hand, forever.
+
+    ``USE_RAPIDPRO_VIEWSET`` is the older boolean form and still works.
+    """
+    config = getattr(settings, "OPENID_CONNECT_VIEWSET_CONFIG", {})
+    dotted_path = config.get("VIEWSET_CLASS")
+    if dotted_path:
+        return import_string(dotted_path)
+    if str_to_bool(config.get("USE_RAPIDPRO_VIEWSET", False)):
+        return RapidProOpenIDConnectViewset
+    return UserModelOpenIDConnectViewset
+
+
+# Every route's url_path, url_name and view kwargs come from the @action
+# decorators. trailing_slash=False keeps paths as /oidc/<server>/login rather
+# than /login/; each action opts back into an optional trailing slash itself.
+router = UnprefixedNameRouter(trailing_slash=False)
+router.register(r"oidc/(?P<auth_server>\w+)", get_viewset_class(), basename="oidc")
+
+urlpatterns = router.urls

--- a/oidc/viewsets.py
+++ b/oidc/viewsets.py
@@ -174,7 +174,12 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
             return bool(self.cookie_secure)
         return bool(getattr(settings, "SESSION_COOKIE_SECURE", False))
 
-    @action(methods=["GET"], detail=False)
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"login/?",
+        url_name="openid_connect_login",
+    )
     def login(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)
@@ -219,6 +224,11 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         detail=False,
         authentication_classes=[],
         renderer_classes=[JSONRenderer],
+        # ``session/?`` like the other three: the router anchors
+        # patterns, so without it a configured probe URL with a
+        # trailing slash 404s.
+        url_path=r"session/?",
+        url_name="openid_connect_session",
     )
     def session(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         """Return the current SSO-backed browser session, without tokens.
@@ -255,7 +265,12 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         """Return the non-secret session payload for ``user``."""
         return {"username": user.username}
 
-    @action(methods=["GET"], detail=False)
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"logout/?",
+        url_name="openid_connect_logout",
+    )
     def logout(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)
@@ -497,7 +512,12 @@ class BaseOpenIDConnectViewset(viewsets.ViewSet):
         if state:
             cache.delete(state_cache_key(state))
 
-    @action(methods=["POST", "GET"], detail=False)
+    @action(
+        methods=["POST", "GET"],
+        detail=False,
+        url_path=r"callback/?",
+        url_name="openid_connect_callback",
+    )
     def callback(self, request: HttpRequest, **kwargs: dict) -> HttpResponse:  # noqa
         auth_server = kwargs.get("auth_server")
         client = self._get_client(auth_server=auth_server)

--- a/tests/project_viewsets.py
+++ b/tests/project_viewsets.py
@@ -1,0 +1,74 @@
+"""
+Stand-ins for a project-owned viewset subclass.
+
+Mirrors how a consumer actually does this -- onadata's
+``OnaOpenIDConnectViewset`` subclasses the concrete viewset to refuse SSO
+login for organization accounts. Kept in its own module, importing only
+``oidc.viewsets``: ``oidc.urls`` resolves ``VIEWSET_CLASS`` at import time, so
+a subclass module that reached back into ``oidc.urls`` would deadlock on a
+circular import.
+"""
+
+from rest_framework.decorators import action
+from rest_framework.renderers import JSONRenderer
+
+from oidc.viewsets import UserModelOpenIDConnectViewset
+
+
+class InjectedViewset(UserModelOpenIDConnectViewset):
+    """Subclass used to prove routing goes to the configured class."""
+
+
+class PlainOverrideViewset(UserModelOpenIDConnectViewset):
+    """Overrides an action the way a consumer naturally would -- and thereby
+    loses its route. Exists so the deploy check has something to catch."""
+
+    def login(self, request, **kwargs):
+        return super().login(request, **kwargs)
+
+
+class RedeclaredOverrideViewset(UserModelOpenIDConnectViewset):
+    """The documented fix: re-apply the decorator on the override."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"login/?",
+        url_name="openid_connect_login",
+    )
+    def login(self, request, **kwargs):
+        return super().login(request, **kwargs)
+
+
+class DroppedViewKwargsViewset(UserModelOpenIDConnectViewset):
+    """Re-declares the route but drops the view kwargs the base set.
+
+    Path, name and verbs all still match, so a comparison on those alone
+    reports nothing -- while ``session`` has quietly regained the default
+    authentication and renderer classes it was declared without.
+    """
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"session/?",
+        url_name="openid_connect_session",
+    )
+    def session(self, request, **kwargs):
+        return super().session(request, **kwargs)
+
+
+class WidenedViewKwargsViewset(UserModelOpenIDConnectViewset):
+    """Adds to the base's view kwargs rather than dropping them. Allowed --
+    the check compares as subsets so a subclass may tighten, not loosen."""
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        authentication_classes=[],
+        renderer_classes=[JSONRenderer],
+        url_path=r"session/?",
+        url_name="openid_connect_session",
+    )
+    def session(self, request, **kwargs):
+        return super().session(request, **kwargs)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+Test the deploy checks registered from ``oidcConfig.ready``.
+"""
+
+import sys
+
+from django.test import TestCase, override_settings
+
+from oidc.checks import check_actions_survive_subclassing
+
+BASE = "oidc.viewsets.UserModelOpenIDConnectViewset"
+FIXTURES = "tests.project_viewsets."
+
+
+def _viewset_class(dotted_path):
+    """``oidc.urls`` reads VIEWSET_CLASS at import time, so the check's own
+    import of it has to see the overridden setting -- drop the cached module
+    and let it re-resolve."""
+    sys.modules.pop("oidc.urls", None)
+    return override_settings(
+        OPENID_CONNECT_VIEWSET_CONFIG={"VIEWSET_CLASS": dotted_path}
+    )
+
+
+class TestActionsSurviveSubclassing(TestCase):
+    def _errors(self, dotted_path):
+        with _viewset_class(dotted_path):
+            return check_actions_survive_subclassing(None)
+
+    def test_the_shipped_viewset_is_clean(self):
+        self.assertEqual(self._errors(BASE), [])
+
+    def test_a_subclass_that_adds_nothing_is_clean(self):
+        self.assertEqual(self._errors(FIXTURES + "InjectedViewset"), [])
+
+    def test_a_plain_override_loses_its_route(self):
+        errors = self._errors(FIXTURES + "PlainOverrideViewset")
+
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+        self.assertIn("login", errors[0].msg)
+
+    def test_re_declaring_the_decorator_is_the_fix(self):
+        self.assertEqual(self._errors(FIXTURES + "RedeclaredOverrideViewset"), [])
+
+    def test_dropping_the_view_kwargs_is_caught(self):
+        """The route matches on path, name and verbs, so only comparing the
+        view kwargs catches this one."""
+        errors = self._errors(FIXTURES + "DroppedViewKwargsViewset")
+
+        self.assertEqual([e.id for e in errors], ["oidc.E002"])
+        self.assertIn("session", errors[0].msg)
+
+    def test_adding_to_the_view_kwargs_is_allowed(self):
+        self.assertEqual(self._errors(FIXTURES + "WidenedViewKwargsViewset"), [])
+
+    def tearDown(self):
+        # The module was popped to force re-resolution; leave the registry as
+        # found so later tests importing oidc.urls get the real settings.
+        sys.modules.pop("oidc.urls", None)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -3,11 +3,14 @@
 Test that oidc urls resolve.
 """
 
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import resolve, reverse
 
 from rest_framework.renderers import JSONRenderer
+from rest_framework.viewsets import ModelViewSet
 
+from oidc.routers import UnprefixedNameRouter
 from oidc.viewsets import UserModelOpenIDConnectViewset
 
 
@@ -47,3 +50,40 @@ class TestUrls(TestCase):
         self.assertEqual(view.actions, {"get": "session"})
         self.assertEqual(view.initkwargs["authentication_classes"], [])
         self.assertEqual(view.initkwargs["renderer_classes"], [JSONRenderer])
+
+    def test_routes_accept_an_optional_trailing_slash(self):
+        """The hand-written URLconf matched by prefix, so /login/ happened to
+        resolve. The router anchors its patterns, so each action opts back in
+        with ``url_path=r"<name>/?"`` -- without that, a deployment whose
+        configured login URL carries a trailing slash starts 404ing."""
+        for path in ("/oidc/abc/login", "/oidc/abc/login/"):
+            with self.subTest(path=path):
+                self.assertEqual(resolve(path).func.cls, UserModelOpenIDConnectViewset)
+
+
+class TestUnprefixedNameRouterScope(TestCase):
+    """The router drops the ``{basename}-`` prefix so this package's
+    ``@action`` names survive. That must not extend to DRF's own
+    ``{basename}-list``/``-detail``: a ``VIEWSET_CLASS`` with CRUD methods
+    would come out as a bare ``list``/``detail``, which collides across
+    routers in one namespace and breaks hyperlinked serializers reversing
+    ``<model>-detail``."""
+
+    def _names(self, viewset):
+        router = UnprefixedNameRouter(trailing_slash=False)
+        router.register(r"things", viewset, basename="thing")
+        return [url.name for url in router.urls]
+
+    def test_action_names_lose_the_basename_prefix(self):
+        self.assertIn(
+            "openid_connect_login", self._names(UserModelOpenIDConnectViewset)
+        )
+
+    def test_crud_routes_keep_drfs_naming(self):
+        class ThingViewSet(ModelViewSet):
+            queryset = User.objects.all()
+            serializer_class = None
+
+        names = self._names(ThingViewSet)
+        self.assertIn("thing-list", names)
+        self.assertIn("thing-detail", names)


### PR DESCRIPTION
### Changes / Features implemented

The URLconf was a hand-written `re_path` list mirroring, by hand, every route the
viewset declares. Routes now come from a DRF router over the `@action` decorators.

**`VIEWSET_CLASS`.** A deployment that subclasses the viewset — onadata does, to refuse
SSO login for organization accounts — could not use `include("oidc.urls")` at all. It
had to copy the whole URLconf and keep it in step with this package forever
([onadata/apps/main/urls.py][ona] does exactly that today). A subclass is now a
settings change.

**Trailing slashes.** The old patterns were unanchored, so `/login/` resolved by
accident. A router anchors them, so each action opts back in with
`url_path=r"<name>/?"` — without that, a deployment whose configured login URL carries
a trailing slash starts 404ing.

`UnprefixedNameRouter` keeps `reverse("oidc:openid_connect_login")` working — a stock
router renames it to `oidc-openid_connect_login`, and that name is public surface (the
unrecoverable-error template and consumers use it). Stripping is limited to dynamic
routes so DRF's own `{basename}-list`/`-detail` keep conventional names.

**`oidc.E002`** covers the trap this introduces: the router builds routes from `@action`
metadata attached to a function, so a subclass overriding an action *without*
re-applying the decorator silently loses the route — a 404 with nothing to say why. The
check compares path, name, verbs and the guarded view kwargs, since dropping
`permission_classes` falls back to `AllowAny` while the route still looks identical.

Salvaged from #124 without the account proxy. `oidc.E001` stays behind with it — it
guards session-stored OIDC tokens, which nothing writes here.

### Steps taken to verify this change does what is intended

- the existing `test_urls.py` assertions on resolved path, `view.cls`, `view.actions`
  and `view.initkwargs` pass unchanged, which is the evidence that the router produces
  the same URLconf the hand-written one did
- 9 new tests: trailing-slash resolution, the router's naming scope (actions unprefixed,
  CRUD routes not), and 6 for E002 — clean base, clean subclass, plain override caught,
  re-declaration accepted, dropped view kwargs caught, widened view kwargs allowed
- full suite: 138 tests, all passing
- flake8 and black clean

### Side effects of implementing this change

**This is a refactor, not a bug fix** — nothing is broken on `main` today. It is worth
review on that basis: the payoff is that consumers stop hand-mirroring the URLconf, and
that E002 makes a silent 404 into a deploy-time error.

- Route *paths* and *names* are unchanged, so `reverse()` calls and existing URLs keep
  working. `/login/` and friends now resolve deliberately rather than by accident.
- A consumer that already hand-mirrors the URLconf is unaffected until it switches to
  `include("oidc.urls")`.
- E002 only reports when `VIEWSET_CLASS` is set, so deployments not using it see nothing.

[ona]: https://github.com/onaio/onadata/blob/main/onadata/apps/main/urls.py

**Before submitting this PR for review, please make sure you have:**

  - [x] Included tests
  - [ ] Updated documentation — `VIEWSET_CLASS` deserves a README entry; happy to add
        it here if reviewers prefer it in this PR